### PR TITLE
feat: Allow using `post` URL in addition to atproto URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This will install the extension under the `_extensions` directory of your Quarto
 To embed comments from a Bluesky post, use the `bluesky-comments` shortcode in your Quarto document:
 
 ````markdown
-{{{< bluesky-comments uri="at://did.plc/rkey" >}}}
+{{{< bluesky-comments post="at://did.plc/rkey" >}}}
 ````
 
 ### Converting Bluesky URLs to AT Protocol URIs
@@ -45,7 +45,7 @@ For example:
 
 3. **Final shortcode:**
    ````markdown
-   {{< bluesky-comments uri="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}
+   {{< bluesky-comments post="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}
    ````
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This will install the extension under the `_extensions` directory of your Quarto
 To embed comments from a Bluesky post, use the `bluesky-comments` shortcode in your Quarto document:
 
 ````markdown
-{{{< bluesky-comments post="at://did.plc/rkey" >}}}
+{{{< bluesky-comments at://did.plc/rkey >}}}
 ````
 
 ### Converting Bluesky URLs to AT Protocol URIs
@@ -45,7 +45,7 @@ For example:
 
 3. **Final shortcode:**
    ````markdown
-   {{< bluesky-comments post="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}
+   {{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 >}}
    ````
 
 ## Configuration

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -21,7 +21,7 @@ class BlueskyComments extends HTMLElement {
   }
 
   async connectedCallback() {
-    const uri = this.getAttribute('uri');
+    const uri = this.getAttribute('post');
     const configStr = this.getAttribute('config');
 
     if (!uri) return;
@@ -249,7 +249,7 @@ class BlueskyComments extends HTMLElement {
       return;
     }
 
-    const [, , did, , rkey] = this.getAttribute('uri').split('/');
+    const [, , did, , rkey] = this.getAttribute('post').split('/');
     const postUrl = `https://bsky.app/profile/${did}/post/${rkey}`;
 
     // Filter and sort replies

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -1,6 +1,7 @@
 class BlueskyComments extends HTMLElement {
   constructor() {
     super();
+    this.post = null;
     this.thread = null;
     this.error = null;
     this.filteredCount = 0;  // Track number of filtered comments
@@ -20,11 +21,12 @@ class BlueskyComments extends HTMLElement {
     this.showMoreReplies = this.showMoreReplies.bind(this);
   }
 
-  async connectedCallback() {
-    const uri = this.getAttribute('post');
-    const configStr = this.getAttribute('config');
+  static get observedAttributes() {
+    return ['post'];
+  }
 
-    if (!uri) return;
+  async connectedCallback() {
+    const configStr = this.getAttribute('config');
 
     // Parse configuration
     if (configStr) {
@@ -38,17 +40,62 @@ class BlueskyComments extends HTMLElement {
 
     // Initialize visible count from config
     this.currentVisibleCount = this.config.visibleComments;
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (oldValue === newValue) return
+
+    if (name === 'post') {
+      this.post = newValue;
+      this.#loadThread();
+    }
+  }
+
+  async #loadThread() {
+    if (!this.post) {
+      this.error = 'Post link (or at:// URI) is required';
+      this.render();
+      return;
+    }
 
     try {
-      await this.fetchThreadData(uri);
+      await this.#fetchThreadData();
+      this.#logAtUri();
       this.render();
-    } catch (err) {
+    } catch (error) {
+      console.error("[bluesky-comments] Error loading comments", error);
       this.error = 'Error loading comments';
       this.render();
     }
   }
 
-  async fetchThreadData(uri) {
+  #convertUri (uri) {
+    if (uri.startsWith('at://')) return uri
+
+    const match = uri.match(/profile\/([\w.]+)\/post\/([\w]+)/)
+    if (match) {
+      const [, did, postId] = match
+      return `at://${did}/app.bsky.feed.post/${postId}`
+    }
+
+    this.error = 'Invalid Bluesky post URL format'
+    return null
+  }
+
+  #logAtUri () {
+    const threadUri = this.thread.post.uri
+    if (this.post === threadUri) {
+      return
+    }
+
+    console.warn(
+      `[bluesky-comments] For more stable and future-proof comments, replace the post URL ${this.post} with the resolved AT-proto URI ${threadUri}.`,
+      { source: this.post, resolved: threadUri }
+    )
+  }
+
+  async #fetchThreadData() {
+    const uri = this.#convertUri(this.post);
     const params = new URLSearchParams({ uri });
     const res = await fetch(
       "https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?" + params.toString(),

--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -71,18 +71,18 @@ function shortcode(args, kwargs, meta)
   local errorMsg = nil
 
   -- Simplify post kwarg. In shortcodes, kwargs is a table of pandoc inlines
-  kwargsPost = pandoc.utils.stringify(kwargs['post'])
+  kwargsUri = pandoc.utils.stringify(kwargs['uri'])
 
-  if kwargsPost ~= '' and #args > 0 then
-    if kwargsPost ~= args[1] then
+  if kwargsUri ~= '' and #args > 0 then
+    if kwargsUri ~= args[1] then
       errorMsg = string.format([[Cannot provide both named and unnamed arguments for post URI:
     * post="%s"
-    * %s]], kwargsPost, args[1])
+    * %s]], kwargsUri, args[1])
     else
       postUri = args[1]
     end
-  elseif kwargsPost ~= '' then
-    postUri = kwargsPost
+  elseif kwargsUri ~= '' then
+    postUri = kwargsUri
   elseif #args == 1 then
     postUri = args[1]
   else

--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -67,7 +67,7 @@ function shortcode(args, kwargs, meta)
   ensureHtmlDeps()
 
   -- Get URI from kwargs or default to empty string
-  local uri = kwargs['uri'] or ''
+  local postUri = kwargs['post'] or ''
 
   -- Get configuration
   local config = getFilterConfig(meta)
@@ -75,9 +75,9 @@ function shortcode(args, kwargs, meta)
   -- Return the HTML div element with config
   return pandoc.RawBlock('html', string.format([[
     <bluesky-comments
-         uri="%s"
+         post="%s"
          config='%s'></bluesky-comments>
-  ]], uri, config))
+  ]], postUri, config))
 end
 
 -- Return the shortcode registration

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -11,7 +11,7 @@ Bluesky Comments is a Quarto shortcode extension that seamlessly integrates Blue
 
 As an example, let's use the following [Bluesky post](https://bsky.app/profile/coatless.bsky.social/post/3lbtwdydxrk26). Feel free to join the conversation by commenting on the post - your comment will appear below when you refresh the page!
 
-{{< bluesky-comments uri="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}
+{{< bluesky-comments post="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}
 
 ## Installation
 
@@ -33,7 +33,7 @@ This will install the extension under the `_extensions` directory of your Quarto
 To embed comments from a Bluesky post, use the `bluesky-comments` shortcode in your Quarto document:
 
 ````markdown
-{{{< bluesky-comments uri="at://did.plc/rkey" >}}}
+{{{< bluesky-comments post="at://did.plc/rkey" >}}}
 ````
 
 ### Converting Bluesky URLs to AT Protocol URIs
@@ -54,7 +54,7 @@ For example:
 
 3. **Final shortcode:**
    ````markdown
-   {{{< bluesky-comments uri="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}}
+   {{{< bluesky-comments post="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}}
    ````
 
 ## Configuration

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -11,7 +11,7 @@ Bluesky Comments is a Quarto shortcode extension that seamlessly integrates Blue
 
 As an example, let's use the following [Bluesky post](https://bsky.app/profile/coatless.bsky.social/post/3lbtwdydxrk26). Feel free to join the conversation by commenting on the post - your comment will appear below when you refresh the page!
 
-{{< bluesky-comments post="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}
+{{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 >}}
 
 ## Installation
 
@@ -33,7 +33,7 @@ This will install the extension under the `_extensions` directory of your Quarto
 To embed comments from a Bluesky post, use the `bluesky-comments` shortcode in your Quarto document:
 
 ````markdown
-{{{< bluesky-comments post="at://did.plc/rkey" >}}}
+{{{< bluesky-comments at://did.plc/rkey >}}}
 ````
 
 ### Converting Bluesky URLs to AT Protocol URIs
@@ -54,7 +54,7 @@ For example:
 
 3. **Final shortcode:**
    ````markdown
-   {{{< bluesky-comments post="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}}
+   {{{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 >}}}
    ````
 
 ## Configuration

--- a/docs/qbluesky-comments-examples.qmd
+++ b/docs/qbluesky-comments-examples.qmd
@@ -59,12 +59,12 @@ at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26
 **Shortcode:**
 
 ```markdown
-{{{< bluesky-comments uri="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}}
+{{{< bluesky-comments post="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}}
 ```
 
 **Live:**
 
-{{< bluesky-comments uri="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}
+{{< bluesky-comments post="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}
 
 ## Medium Thread
 
@@ -83,13 +83,13 @@ at://did:plc:eclio37ymobqex2ncko63h4r/app.bsky.feed.post/3lbvio3i5d22f
 **Shortcode:**
 
 ```markdown
-{{{< bluesky-comments uri="at://did:plc:eclio37ymobqex2ncko63h4r/app.bsky.feed.post/3lbvio3i5d22f" >}}}
+{{{< bluesky-comments post="at://did:plc:eclio37ymobqex2ncko63h4r/app.bsky.feed.post/3lbvio3i5d22f" >}}}
 ```
 
 
 **Live:**
 
-{{< bluesky-comments uri="at://did:plc:eclio37ymobqex2ncko63h4r/app.bsky.feed.post/3lbvio3i5d22f" >}}
+{{< bluesky-comments post="at://did:plc:eclio37ymobqex2ncko63h4r/app.bsky.feed.post/3lbvio3i5d22f" >}}
 
 ## Massive Thread
 
@@ -108,10 +108,10 @@ at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3lbqta5lnck2i
 **Shortcode:**
 
 ```markdown
-{{{< bluesky-comments uri="at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3lbqta5lnck2i" >}}}
+{{{< bluesky-comments post="at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3lbqta5lnck2i" >}}}
 ```
 
 **Live:**
 
-{{< bluesky-comments uri="at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3lbqta5lnck2i" >}}
+{{< bluesky-comments post="at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3lbqta5lnck2i" >}}
 

--- a/docs/qbluesky-comments-examples.qmd
+++ b/docs/qbluesky-comments-examples.qmd
@@ -59,12 +59,12 @@ at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26
 **Shortcode:**
 
 ```markdown
-{{{< bluesky-comments post="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}}
+{{{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 >}}}
 ```
 
 **Live:**
 
-{{< bluesky-comments post="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}
+{{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 >}}
 
 ## Medium Thread
 
@@ -83,13 +83,13 @@ at://did:plc:eclio37ymobqex2ncko63h4r/app.bsky.feed.post/3lbvio3i5d22f
 **Shortcode:**
 
 ```markdown
-{{{< bluesky-comments post="at://did:plc:eclio37ymobqex2ncko63h4r/app.bsky.feed.post/3lbvio3i5d22f" >}}}
+{{{< bluesky-comments at://did:plc:eclio37ymobqex2ncko63h4r/app.bsky.feed.post/3lbvio3i5d22f >}}}
 ```
 
 
 **Live:**
 
-{{< bluesky-comments post="at://did:plc:eclio37ymobqex2ncko63h4r/app.bsky.feed.post/3lbvio3i5d22f" >}}
+{{< bluesky-comments at://did:plc:eclio37ymobqex2ncko63h4r/app.bsky.feed.post/3lbvio3i5d22f >}}
 
 ## Massive Thread
 
@@ -108,10 +108,10 @@ at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3lbqta5lnck2i
 **Shortcode:**
 
 ```markdown
-{{{< bluesky-comments post="at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3lbqta5lnck2i" >}}}
+{{{< bluesky-comments at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3lbqta5lnck2i >}}}
 ```
 
 **Live:**
 
-{{< bluesky-comments post="at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3lbqta5lnck2i" >}}
+{{< bluesky-comments at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3lbqta5lnck2i >}}
 

--- a/docs/qbluesky-comments-faq.qmd
+++ b/docs/qbluesky-comments-faq.qmd
@@ -30,7 +30,7 @@ No authentication is required as the extension uses Bluesky's public API endpoin
 Add the following shortcode to your Quarto document where you want the comments to appear:
 
 ```markdown
-{{< bluesky-comments post="at://did.plc/app.bsky.feed.post/threadid" >}}
+{{< bluesky-comments at://did.plc/app.bsky.feed.post/threadid >}}
 ```
 
 ## Where do I find the URI for a Bluesky post?

--- a/docs/qbluesky-comments-faq.qmd
+++ b/docs/qbluesky-comments-faq.qmd
@@ -30,7 +30,7 @@ No authentication is required as the extension uses Bluesky's public API endpoin
 Add the following shortcode to your Quarto document where you want the comments to appear:
 
 ```markdown
-{{< bluesky-comments uri="at://did.plc/app.bsky.feed.post/threadid" >}}
+{{< bluesky-comments post="at://did.plc/app.bsky.feed.post/threadid" >}}
 ```
 
 ## Where do I find the URI for a Bluesky post?


### PR DESCRIPTION
This PR updates the component to also accept a post URL (i.e. copied directly from the browser or Bluesky client) that is used to initially look up the thread. (Part 1 of [the changes described in this comment](https://github.com/quarto-ext/bluesky-comments/issues/3#issuecomment-2511914920).)

Once we've resolved the thread, if the post URI is different from the one provided by the user, we emit a console message with both URLs that can be used to update the post.

Further, authors no longer need to use the `uri=""` attribute in the shortcode, they can just pass the URI or post URL directly. If you try to use both, we'll throw an error at render.

In the web component, the `uri` attribute is now named `post`.

After this change, the following are all equivalent:

```markdown
{{< bluesky-comments https://bsky.app/profile/coatless.bsky.social/post/3lbtwdydxrk26 >}}
{{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 >}}

<!-- for backwards compat with existing coatless-quarto/bluesky-comments users -->
{{< bluesky-comments uri="https://bsky.app/profile/coatless.bsky.social/post/3lbtwdydxrk26" >}}
{{< bluesky-comments uri="at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26" >}}
```