### PR TITLE
feat: Allow post-id only by using `profile` from metadata

### DIFF
--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -57,6 +57,7 @@ class BlueskyComments extends HTMLElement {
     if (oldValue === newValue) return
 
     if (name === 'post') {
+      this.#setPostUri(newValue);
       this.#loadThread();
     }
   }

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -1,6 +1,7 @@
 class BlueskyComments extends HTMLElement {
   constructor() {
     super();
+    this._initialized = false;
     this.post = null;
     this.thread = null;
     this.error = null;
@@ -38,17 +39,39 @@ class BlueskyComments extends HTMLElement {
       }
     }
 
+    this.#setPostUri(this.getAttribute('post'));
+
     // Initialize visible count from config
     this.currentVisibleCount = this.config.visibleComments;
+    if (!this._initialized) {
+      this._initialized = true
+      this.#loadThread();
+    }
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
+    if (!this._initialized) {
+      // connectedCallback handles first load but is async
+      return
+    }
     if (oldValue === newValue) return
 
     if (name === 'post') {
-      this.post = newValue;
       this.#loadThread();
     }
+  }
+
+  #setPostUri(newValue) {
+    if (newValue && !/^(https?|at):\/\//.test(newValue)) {
+      if (this.config.profile) {
+        if (this.config.profile.startsWith("did:")) {
+          newValue = `at://${this.config.profile}/app.bsky.feed.post/${newValue}`
+        } else {
+          newValue = `https://bsky.app/profile/${this.config.profile.replace("@", "")}/post/${newValue}`
+        }
+      }
+    }
+    this.post = newValue;
   }
 
   async #loadThread() {

--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -86,7 +86,7 @@ function shortcode(args, kwargs, meta)
   if kwargsUri ~= '' and #args > 0 then
     if kwargsUri ~= args[1] then
       errorMsg = string.format([[Cannot provide both named and unnamed arguments for post URI:
-    * post="%s"
+    * uri="%s"
     * %s]], kwargsUri, args[1])
     else
       postUri = args[1]

--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -42,6 +42,16 @@ local function getFilterConfig(meta)
     filterConfig.visibleSubComments = tonumber(pandoc.utils.stringify(config['visible-subcomments']))
   end
 
+  -- Add any additional config values
+  for key, value in pairs(config) do
+    -- Convert key from kebab-case to camelCase
+    local camelKey = key:gsub("%-(%w)", function(match) return match:upper() end)
+    -- Only add if not already in filterConfig
+    if filterConfig[camelKey] == nil then
+      filterConfig[camelKey] = pandoc.utils.stringify(value)
+    end
+  end
+
   -- Convert to JSON string
   return quarto.json.encode(filterConfig)
 end

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -32,3 +32,7 @@ website:
 format:
   html:
     toc: true
+
+bluesky-comments:
+  # profile: did:plc:fgeozid7uyx2lfz3yo7zvm3b
+  profile: coatless.bsky.social

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -34,5 +34,5 @@ format:
     toc: true
 
 bluesky-comments:
-  # profile: did:plc:fgeozid7uyx2lfz3yo7zvm3b
-  profile: coatless.bsky.social
+  # profile: coatless.bsky.social
+  profile: did:plc:fgeozid7uyx2lfz3yo7zvm3b

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -30,32 +30,51 @@ This will install the extension under the `_extensions` directory of your Quarto
 
 ## Usage
 
-To embed comments from a Bluesky post, use the `bluesky-comments` shortcode in your Quarto document:
+To embed comments from a Bluesky post, use the `bluesky-comments` shortcode in your Quarto document, replacing `post_url` with the link to the Bluesky post that serves as the start of your comments.
 
 ````markdown
-{{{< bluesky-comments at://did.plc/rkey >}}}
+{{{< bluesky-comments post_url >}}}
 ````
 
-### Converting Bluesky URLs to AT Protocol URIs
+Here's the shortcode we used in the example above:
 
-To get the correct URI format, use the [Bluesky/AT Protocol URL ↔ Identifier Converter](https://web-apps.thecoatlessprofessor.com/bluesky/profile-or-post-to-did-at-uri.html).
+````markdown
+{{{< bluesky-comments https://bsky.app/profile/coatless.bsky.social/post/3lbtwdydxrk26 >}}}
+````
 
-For example:
+Alternatively, you can add your Bluesky profile handle to your document's YAML frontmatter (or in the `_quarto.yml` configuration file). Then you can just use the post's record key (the identifier at the end of the URL):
 
-1. **Original URL:**
-   ```
-   https://bsky.app/profile/coatless.bsky.social/post/3lbtwdydxrk26
-   ```
+````markdown
+---
+bluesky-comments:
+  profile: coatless.bsky.social
+---
 
-2. **Converted AT-URI:**
-   ```
-   at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26
-   ```
+{{{< bluesky-comments 3lbtwdydxrk26 >}}}
+````
 
-3. **Final shortcode:**
-   ````markdown
-   {{{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 >}}}
+### Durable Bluesky post links
+
+Post record keys never change on Bluesky, but user handles may.
+If you change your Bluesky handle in the future (or if you link to a post by someone else and _they_ update their handle), your comments may break.
+
+To avoid breakage, you have a few choices:
+
+1. Use the full [AT Protocol URL](qbluesky-comments-faq.qmd#convert-to-atproto-uri) for the post. Anywhere that `{{{< bluesky-comments >}}}` takes a post URL, it also accepts an `at://` atproto URI.
+
+2. Set your `bluesky-comments.profile` to the [Decentralized Identifier](qbluesky-comments-faq.qmd#convert-to-atproto-uri) (DID) for your profile and use only the post record key in the shortcode:
+
+   ````markdow
+   ---
+   bluesky-comments:
+     profile: did:plc:fgeozid7uyx2lfz3yo7zvm3b  # coatless.bsky.social
+   ---
+
+   {{{< bluesky-comments 3lbtwdydxrk26 >}}}
    ````
+
+3. Or you can use your profile URL, knowing that if you change it in the future you may need to update your site again.
+
 
 ## Configuration
 
@@ -65,6 +84,7 @@ The extension can be configured through your document's YAML frontmatter or the 
 ---
 title: "My Document"
 bluesky-comments:
+  profile: did:plc:fgeozid7uyx2lfz3yo7zvm3b  # coatless.bsky.social
   mute-patterns:
     - "📌"
     - "🔥"
@@ -79,6 +99,7 @@ bluesky-comments:
 
 ### Available Options
 
+- `profile`: A string with the user profile as a handle or [decentralized identifier](qbluesky-comments-faq.qmd#convert-to-atproto-uri)
 - `mute-patterns`: An array of strings or regex patterns (enclosed in `/`) to filter out comments containing specific text
 - `mute-users`: An array of Bluesky DIDs to filter out comments from specific users
 - `filter-empty-replies`: Boolean flag to filter out empty or very short replies (default: `true`)

--- a/docs/qbluesky-comments-faq.qmd
+++ b/docs/qbluesky-comments-faq.qmd
@@ -30,17 +30,38 @@ No authentication is required as the extension uses Bluesky's public API endpoin
 Add the following shortcode to your Quarto document where you want the comments to appear:
 
 ```markdown
-{{< bluesky-comments at://did.plc/app.bsky.feed.post/threadid >}}
+<!-- Using the post URL -->
+{{< bluesky-comments https://bsky.app/profile/{handle}/post/{thread_id} >>}}
+
+<!-- Using the AT Protocol URI -->
+{{< bluesky-comments at://{did_plc}/app.bsky.feed.post/{thread_id} >}}
 ```
 
-## Where do I find the URI for a Bluesky post?
+### Converting Bluesky URLs to AT Protocol URIs {#convert-to-atproto-uri}
 
-1. Go to the Bluesky post you want to embed
-2. The URL will look like: `https://bsky.app/profile/username.bsky.social/post/threadid`
-3. Convert this to the AT protocol format: `at://did.plc/app.bsky.feed.post/threadid` by using [Bluesky/AT Protocol
-URL ↔ Identifier Converter](https://web-apps.thecoatlessprofessor.com/bluesky/profile-or-post-to-did-at-uri.html).
+To get the [At Protocol URI](https://atproto.com/specs/at-uri-scheme) for a post or user profile, use the [Bluesky/AT Protocol URL ↔ Identifier Converter](https://web-apps.thecoatlessprofessor.com/bluesky/profile-or-post-to-did-at-uri.html).
 
-You can find the DID (Decentralized Identifier) by viewing the profile of the post author.
+For example:
+
+1. **Original URL:**
+   ```
+   https://bsky.app/profile/coatless.bsky.social/post/3lbtwdydxrk26
+   ```
+
+2. **Converted AT-URI:**
+   ```
+   at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26
+   ```
+
+3. **Final shortcode:**
+   ````markdown
+   {{{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 >}}}
+   ````
+
+This tool can also be used to find the DID (Decentralized Identifier) of a Bluesky handle.
+The DID starts with `did:plc:` and uniquely identifies a poster.
+For example, James' profile is currently `coatless.bsky.social`, but one day he may decide to change it to use domain that he owns.
+When he changes his profile handle, his DID will remain the same: `did:plc:fgeozid7uyx2lfz3yo7zvm3b`.
 
 ## Can I customize the appearance?
 

--- a/docs/tests/index.qmd
+++ b/docs/tests/index.qmd
@@ -1,0 +1,10 @@
+---
+title: Test Cases
+
+listing:
+  contents: "test-*.qmd"
+  type: table
+  fields:
+    - title
+    - description
+---

--- a/docs/tests/test-post-atproto-uri.qmd
+++ b/docs/tests/test-post-atproto-uri.qmd
@@ -1,0 +1,48 @@
+---
+title: "Test: Shortcode with atproto URI"
+description: Test that the shortcode works with Bluesky atproto post URIs.
+
+bluesky-comments:
+  profile: did:plc:72jpccg3u3vbohc67rqrplei
+---
+
+## As direct argument
+
+```markdown
+{{{< bluesky-comments at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lbu5opiixc2j >}}}
+```
+
+{{< bluesky-comments at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lbu5opiixc2j >}}
+
+## As named `uri` argument
+
+```markdown
+{{{< bluesky-comments uri="at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lbu5opiixc2j" >}}}
+```
+
+{{< bluesky-comments uri="at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lbu5opiixc2j" >}}
+
+## Using `profile` from metadata
+
+This post includes the following in its frontmatter:
+
+```yaml
+bluesky-comments:
+  profile: did:plc:72jpccg3u3vbohc67rqrplei
+```
+
+### As direct argument with post ID
+
+```markdown
+{{{< bluesky-comments 3lbu5opiixc2j >}}}
+```
+
+{{< bluesky-comments 3lbu5opiixc2j >}}
+
+### As named `uri` argument with ID
+
+```markdown
+{{{< bluesky-comments uri="3lbu5opiixc2j" >}}}
+```
+
+{{< bluesky-comments uri="3lbu5opiixc2j" >}}

--- a/docs/tests/test-post-url.qmd
+++ b/docs/tests/test-post-url.qmd
@@ -1,0 +1,52 @@
+---
+title: "Test: Shortcode with post URL"
+description: Test that the shortcode works with Bluesky post URLs.
+
+bluesky-comments:
+  profile: grrrck.xyz
+---
+
+::: callout-important
+A console warning should be generated for every comments section in this test, giving the user the resolved atproto URI.
+:::
+
+## As direct argument
+
+```markdown
+{{{< bluesky-comments https://bsky.app/profile/grrrck.xyz/post/3lbu5opiixc2j >}}}
+```
+
+{{< bluesky-comments https://bsky.app/profile/grrrck.xyz/post/3lbu5opiixc2j >}}
+
+## As named `uri` argument
+
+```markdown
+{{{< bluesky-comments uri="https://bsky.app/profile/grrrck.xyz/post/3lbu5opiixc2j" >}}}
+```
+
+{{< bluesky-comments uri="https://bsky.app/profile/grrrck.xyz/post/3lbu5opiixc2j" >}}
+
+## Using `profile` from metadata
+
+This post includes the following in its frontmatter:
+
+```yaml
+bluesky-comments:
+  profile: grrrck.xyz
+```
+
+### As direct argument with post ID
+
+```markdown
+{{{< bluesky-comments 3lbu5opiixc2j >}}}
+```
+
+{{< bluesky-comments 3lbu5opiixc2j >}}
+
+### As named `uri` argument with ID
+
+```markdown
+{{{< bluesky-comments uri="3lbu5opiixc2j" >}}}
+```
+
+{{< bluesky-comments uri="3lbu5opiixc2j" >}}


### PR DESCRIPTION
Part 2 of addressing [the changes described in this comment](https://github.com/quarto-ext/bluesky-comments/issues/3#issuecomment-2511914920). 

> I've also implemented a change where you can put your profile in `_quarto.yml` or the post metadata
> 
> ```yaml
> bluesky-comments:
>   # profile: did:plc:fgeozid7uyx2lfz3yo7zvm3b
>   profile: coatless.bsky.social
> ```
> 
> and then use the post ID directly in the shortcode
> 
> ```markdown
> {{< bluesky-comments 3lbtwdydxrk26 >}}
> ```
> 
> This would make it easier to a) globally change the profile name or b) lookup your DID once and never have to do it again.

This PR also adds a set of unlisted tests to `docs/` that can be viewed at `{site-preview}/tests`. The goal is to have a set of pages for quick manual checks (that we might automate at some point).