### PR TITLE
docs(refactor): Simplify docs URLs

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -18,16 +18,16 @@ website:
       - text: "Home"
         file: index.qmd
       - text: "Examples"
-        file: qbluesky-comments-examples.qmd
+        file: examples.qmd
       - section: "Support"
         contents:
         - text: "FAQ"
-          href: qbluesky-comments-faq.qmd
+          href: faq.qmd
         - text: "Submit an issue"
           href: https://github.com/quarto-ext/bluesky-comments/issues/new/choose
       - section: "Extra"
         contents:
-        - qbluesky-comments-release-notes.qmd
+        - news.qmd
 
 format:
   html:

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -2,6 +2,8 @@
 title: "Bluesky Comments Example"
 format: html
 callout-appearance: simple
+aliases:
+  - qbluesky-comments-examples
 bluesky-comments:
   mute-patterns:
     - "📌"
@@ -114,4 +116,3 @@ at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3lbqta5lnck2i
 **Live:**
 
 {{< bluesky-comments at://did:plc:vjug55kidv6sye7ykr5faxxn/app.bsky.feed.post/3lbqta5lnck2i >}}
-

--- a/docs/faq.qmd
+++ b/docs/faq.qmd
@@ -1,5 +1,7 @@
 ---
 title: Bluesky Comments Extension FAQ
+aliases:
+  - qbluesky-comments-faq
 ---
 
 ## What is the Bluesky Comments extension?

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -60,9 +60,9 @@ If you change your Bluesky handle in the future (or if you link to a post by som
 
 To avoid breakage, you have a few choices:
 
-1. Use the full [AT Protocol URL](qbluesky-comments-faq.qmd#convert-to-atproto-uri) for the post. Anywhere that `{{{< bluesky-comments >}}}` takes a post URL, it also accepts an `at://` atproto URI.
+1. Use the full [AT Protocol URL](faq.qmd#convert-to-atproto-uri) for the post. Anywhere that `{{{< bluesky-comments >}}}` takes a post URL, it also accepts an `at://` atproto URI.
 
-2. Set your `bluesky-comments.profile` to the [Decentralized Identifier](qbluesky-comments-faq.qmd#convert-to-atproto-uri) (DID) for your profile and use only the post record key in the shortcode:
+2. Set your `bluesky-comments.profile` to the [Decentralized Identifier](faq.qmd#convert-to-atproto-uri) (DID) for your profile and use only the post record key in the shortcode:
 
    ````markdow
    ---
@@ -99,7 +99,7 @@ bluesky-comments:
 
 ### Available Options
 
-- `profile`: A string with the user profile as a handle or [decentralized identifier](qbluesky-comments-faq.qmd#convert-to-atproto-uri)
+- `profile`: A string with the user profile as a handle or [decentralized identifier](faq.qmd#convert-to-atproto-uri)
 - `mute-patterns`: An array of strings or regex patterns (enclosed in `/`) to filter out comments containing specific text
 - `mute-users`: An array of Bluesky DIDs to filter out comments from specific users
 - `filter-empty-replies`: Boolean flag to filter out empty or very short replies (default: `true`)

--- a/docs/news.qmd
+++ b/docs/news.qmd
@@ -6,6 +6,8 @@ engine: markdown
 format:
   html:
     toc: true
+aliases:
+  - qbluesky-comments-release-notes
 ---
 
 # 0.0.0-dev.1: ?? (??-??-????)


### PR DESCRIPTION
Moves document files to easier-to-remember locations:

* `qbluesky-comments-examples` → `examples`
* `qbluesky-comments-faq` → `faq`
* `qbluesky-comments-release-notes` → `news`