### PR TITLE
feat: Resolve atproto URI during render

### DIFF
--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -1,3 +1,6 @@
+local bluesky = require("bluesky-resolve")
+
+
 -- Get filter configuration from meta and convert to JSON
 local function getFilterConfig(meta)
   -- Access the extension configuration from meta
@@ -52,8 +55,7 @@ local function getFilterConfig(meta)
     end
   end
 
-  -- Convert to JSON string
-  return quarto.json.encode(filterConfig)
+  return filterConfig
 end
 
 -- Register HTML dependencies for the shortcode
@@ -61,9 +63,38 @@ local function ensureHtmlDeps()
   quarto.doc.add_html_dependency({
     name = 'bluesky-comments',
     version = '1.0.0',
-    scripts = {'bluesky-comments.js'},
-    stylesheets = {'styles.css'}
+    scripts = { 'bluesky-comments.js' },
+    stylesheets = { 'styles.css' }
   })
+end
+
+local function composePostUri(postUri, config)
+  postUri = pandoc.utils.stringify(postUri or "")
+
+  if postUri:match("^at://") or postUri:match("^https?://") then
+    return postUri
+  end
+
+  if postUri == "" then
+    -- TODO: look up the postUri from meta
+    return postUri
+  end
+
+  local profile = pandoc.utils.stringify(config.profile or "")
+
+  if profile == "" then
+    quarto.log.error(
+      "[bluesky-comments] Post record key " .. postUri ..
+      " provided but `bluesky-comments.profile` metadata is not set."
+    )
+    return ''
+  end
+
+  if profile:match("^did:") then
+    return bluesky.createAtUri(profile, postUri)
+  end
+
+  return bluesky.createPostUrl(profile, postUri)
 end
 
 -- Main shortcode function
@@ -72,6 +103,9 @@ function shortcode(args, kwargs, meta)
   if not quarto.doc.is_format("html:js") then
     return pandoc.Null()
   end
+
+  -- Get configuration
+  local config = getFilterConfig(meta)
 
   -- Ensure HTML dependencies are added
   ensureHtmlDeps()
@@ -95,24 +129,30 @@ function shortcode(args, kwargs, meta)
     postUri = kwargsUri
   elseif #args == 1 then
     postUri = args[1]
-  else
-    errorMsg = "shortcode requires exactly one unnamed argument: the Bluesky post URL or AT-proto URI."
   end
 
-  if errorMsg ~= nil then
+  if postUri == nil then
+    errorMsg = errorMsg or "Shortcode requires the Bluesky post URL, AT-proto URI, or post record key as an unnamed argument."
     quarto.log.error("[bluesky-comments] " .. errorMsg)
     return ""
   end
 
-  -- Get configuration
-  local config = getFilterConfig(meta)
+  postUri = composePostUri(postUri, config)
+  if postUri == "" then
+    return ""
+  end
+
+  local atUri = bluesky.convertUrlToAtUri(postUri)
+  if atUri and atUri ~= '' then
+    postUri = atUri
+  end
 
   -- Return the HTML div element with config
   return pandoc.RawBlock('html', string.format([[
     <bluesky-comments
          post="%s"
          config='%s'></bluesky-comments>
-  ]], pandoc.utils.stringify(postUri or ''), config))
+  ]], postUri, quarto.json.encode(config)))
 end
 
 -- Return the shortcode registration

--- a/_extensions/bluesky-comments/bluesky-resolve.lua
+++ b/_extensions/bluesky-comments/bluesky-resolve.lua
@@ -1,0 +1,94 @@
+local BlueskyAPI = {}
+
+-- Base Bluesky API URL
+local BASE_API_URL = "https://api.bsky.app"
+local BASE_APP_URL = "https://bsky.app"
+
+
+-- Extract handle and post ID from a Bluesky URL
+-- Example: https://bsky.app/profile/handle.bsky.social/post/1234
+---@param url string A Bluesky post URL
+---@return string handle The extracted user's handle
+---@return string postId The extracted post ID
+local function extractPostInfo(url)
+  local handle, postId = url:match("bsky%.app/profile/([^/]+)/post/([^/]+)")
+  if not handle or not postId then
+    error("Invalid Bluesky URL format")
+  end
+  return handle, postId
+end
+
+-- Global cache for resolved handles
+local BSKY_RESOLVED_HANDLES = _G.BSKY_RESOLVED_HANDLES or {}
+_G.BSKY_RESOLVED_HANDLES = BSKY_RESOLVED_HANDLES
+
+-- Resolve a handle to a DID.
+-- See <https://docs.bsky.app/docs/advanced-guides/resolving-identities>.
+---@param handle string The user's handle to be resolved
+---@return string did The resolved DID for the user
+function BlueskyAPI.resolveHandle(handle)
+  if BSKY_RESOLVED_HANDLES[handle] ~= nil then
+    return BSKY_RESOLVED_HANDLES[handle]
+  end
+
+  local url = string.format("%s/xrpc/com.atproto.identity.resolveHandle?handle=%s", BASE_API_URL, handle)
+
+  quarto.log.info("[bluesky-comments] Request: " .. url)
+  local mt, contents = pandoc.mediabag.fetch(url)
+  quarto.log.info("[bluesky-comments] Response: ", contents)
+
+  if not contents then
+    error("Failed to resolve handle: " .. handle)
+  end
+
+  local data = quarto.json.decode(contents)
+  BSKY_RESOLVED_HANDLES[handle] = data.did   -- Cache the resolved DID
+  return data.did
+end
+
+-- Create an AT Protocol URI from a DID and post ID
+---@param did string
+---@param postId string
+---@return string
+function BlueskyAPI.createAtUri(did, postId)
+  return string.format("at://%s/app.bsky.feed.post/%s", did, postId)
+end
+
+-- Create a Bluesky post URL from a handle and post ID
+---@param handle string
+---@param postId string
+---@return string
+function BlueskyAPI.createPostUrl(handle, postId)
+  return string.format("%s/profile/%s/post/%s", BASE_APP_URL, handle, postId)
+end
+
+---Convert a Bluesky post URL to an atproto URI
+---
+---See <https://docs.bsky.app/docs/advanced-guides/posts> and
+---<https://web-apps.thecoatlessprofessor.com/bluesky/profile-or-post-to-did-at-uri.html>.
+---@param url string The URL to convert, possibly already an `at://` URI
+---@return string|nil atUri Returns the resolved atproto URI for the post, or `nil` if unable to convert the post URL.
+function BlueskyAPI.convertUrlToAtUri(url)
+  if url:match("^at://") then
+    return url
+  end
+
+  quarto.log.info("[bluesky-comments] Resolving post: " .. url)
+
+  local atUri
+  local success, err = pcall(function()
+    local handle, postId = extractPostInfo(url)
+    local did = BlueskyAPI.resolveHandle(handle)
+    atUri = BlueskyAPI.createAtUri(did, postId)
+  end)
+
+  if not success then
+    quarto.log.error("Error resolving aturi for post " .. url .. ". Error: " .. err)
+    return nil
+  end
+
+  quarto.log.info("[bluesky-comments] Resolved aturi: " .. atUri)
+  return atUri
+end
+
+return BlueskyAPI

--- a/_extensions/bluesky-comments/bluesky-resolve.lua
+++ b/_extensions/bluesky-comments/bluesky-resolve.lua
@@ -62,6 +62,10 @@ function BlueskyAPI.createPostUrl(handle, postId)
   return string.format("%s/profile/%s/post/%s", BASE_APP_URL, handle, postId)
 end
 
+-- Global cache for resolved URIs
+local BSKY_RESOLVED_URIS = _G.BSKY_RESOLVED_URIS or {}
+_G.BSKY_RESOLVED_URIS = BSKY_RESOLVED_URIS
+
 ---Convert a Bluesky post URL to an atproto URI
 ---
 ---See <https://docs.bsky.app/docs/advanced-guides/posts> and
@@ -85,6 +89,15 @@ function BlueskyAPI.convertUrlToAtUri(url)
   if not success then
     quarto.log.error("Error resolving aturi for post " .. url .. ". Error: " .. err)
     return nil
+  end
+
+  if BSKY_RESOLVED_URIS[url] == nil then
+    quarto.log.output(
+      "[bluesky-comments] Resolved Bluesky post:" ..
+      "\n    source: " .. url ..
+      "\n  resolved: " .. atUri
+    )
+    BSKY_RESOLVED_URIS[url] = atUri
   end
 
   quarto.log.info("[bluesky-comments] Resolved aturi: " .. atUri)

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -75,6 +75,16 @@ To avoid breakage, you have a few choices:
 
 3. Or you can use your profile URL, knowing that if you change it in the future you may need to update your site again.
 
+`bluesky-comments` will attempt to convert the post URL to an AT Protocol URI when rendering your document.
+If a post URL is successfully converted, you'll find a message like the following in the output of `quarto render`:
+
+```
+[bluesky-comments] Resolved Bluesky post:
+    source: https://bsky.app/profile/coatless.bsky.social/post/3lbtwdydxrk26
+  resolved: at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26
+```
+
+You can use this information to replace the source post URL with the resolved AT Protocol URI, or you can replace your profile handle with the DID from the resolved URI.
 
 ## Configuration
 

--- a/docs/tests/test-expected-errors.qmd
+++ b/docs/tests/test-expected-errors.qmd
@@ -1,0 +1,43 @@
+---
+title: "Test: Expected Errors"
+description: Rendering this document produces console errors (but does not break render)
+
+bluesky-comments:
+  profile: ~
+---
+
+## Post record key without profile
+
+````markdown
+{{{< bluesky-comments 3lbtwdydxrk26 >}}}
+````
+
+{{< bluesky-comments 3lbtwdydxrk26 >}}
+
+## Missing post entirely
+
+````markdown
+{{{< bluesky-comments >}}}
+````
+
+{{< bluesky-comments >}}
+
+## Post specified twice
+
+````markdown
+{{{< bluesky-comments https://bsky.app/profile/grrrck.xyz/post/3lbu5opiixc2j uri="https://bsky.app/profile/coatless.bsky.social" >}}}
+````
+
+{{< bluesky-comments https://bsky.app/profile/grrrck.xyz/post/3lbu5opiixc2j uri="https://bsky.app/profile/coatless.bsky.social" >}}
+
+## Expected
+
+When rendered, this document should produce three non-blocking errors and no comments or output will appear in the document.
+
+```
+(E) [bluesky-comments] Post record key 3lbtwdydxrk26 provided but `bluesky-comments.profile` metadata is not set.
+(E) [bluesky-comments] Shortcode requires the Bluesky post URL, AT-proto URI, or post record key as an unnamed argument.
+(E) [bluesky-comments] Cannot provide both named and unnamed arguments for post URI:
+    * uri="https://bsky.app/profile/coatless.bsky.social"
+    * https://bsky.app/profile/grrrck.xyz/post/3lbu5opiixc2j
+```


### PR DESCRIPTION
This PR uses the `pandoc.mediabag.fetch()` API to query the Bluesky API to resolve user handles.

If we convert a post URL to an atproto URI, we output a message in the render log

```
[bluesky-comments] Resolved Bluesky post:
    source: https://bsky.app/profile/grrrck.xyz/post/3lbu5opiixc2j
  resolved: at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lbu5opiixc2j
```

The resolved URI is then baked into the output. I don't think it's guaranteed that future renders will have access to this information, but at least the published content won't break. (I'm not sure but I don't think `freeze` includes the output of shortcodes, just computations.)