### PR TITLE
refactor: Consolidate error handling logic

### DIFF
--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -1,4 +1,5 @@
 local bluesky = require("bluesky-api")
+local utils = require("utils")
 
 
 -- Get filter configuration from meta
@@ -83,11 +84,10 @@ local function composePostUri(postUri, config)
   local profile = pandoc.utils.stringify(config.profile or "")
 
   if profile == "" then
-    quarto.log.error(
-      "[bluesky-comments] Post record key " .. postUri ..
+    return utils.abort(
+      "Post record key " .. postUri ..
       " provided but `bluesky-comments.profile` metadata is not set."
     )
-    return ''
   end
 
   if profile:match("^did:") then
@@ -133,12 +133,12 @@ function shortcode(args, kwargs, meta)
 
   if postUri == nil then
     errorMsg = errorMsg or "Shortcode requires the Bluesky post URL, AT-proto URI, or post record key as an unnamed argument."
-    quarto.log.error("[bluesky-comments] " .. errorMsg)
+    utils.abort(errorMsg)
     return ""
   end
 
   postUri = composePostUri(postUri, config)
-  if postUri == "" then
+  if (postUri or "") == "" then
     return ""
   end
 

--- a/_extensions/bluesky-comments/utils.lua
+++ b/_extensions/bluesky-comments/utils.lua
@@ -1,0 +1,24 @@
+local utils = {}
+
+function utils.bcMessage(msg)
+  return string.format("[bluesky-comments] %s", msg)
+end
+
+function utils.abort(msg)
+  -- TODO: Actually throw when Quarto has better support for exiting render from shortcodes
+  error("\n" .. utils.bcMessage(msg) .. "\n")
+end
+
+function utils.log_error(msg)
+  quarto.log.error(utils.bcMessage(msg))
+end
+
+function utils.log_info(msg)
+  quarto.log.info(utils.bcMessage(msg))
+end
+
+function utils.log_output(msg)
+  quarto.log.output(utils.bcMessage(msg))
+end
+
+return utils

--- a/docs/tests/test-expected-errors.qmd
+++ b/docs/tests/test-expected-errors.qmd
@@ -14,6 +14,7 @@ bluesky-comments:
 
 {{< bluesky-comments 3lbtwdydxrk26 >}}
 
+
 ## Missing post entirely
 
 ````markdown
@@ -21,6 +22,25 @@ bluesky-comments:
 ````
 
 {{< bluesky-comments >}}
+
+
+## Invalid post URL
+
+```markdown
+{{{< bluesky-comments https://example.com/bad/ >}}}
+```
+
+{{< bluesky-comments https://example.com/bad/ >}}
+
+
+## Invalid handle
+
+````markdown
+{{{< bluesky-comments https://bsky.app/profile/bad.bad.bad.bad.bad/post/3lbu5opiixc2j >}}}
+````
+
+{{< bluesky-comments https://bsky.app/profile/bad.bad.bad.bad.bad/post/3lbu5opiixc2j >}}
+
 
 ## Post specified twice
 
@@ -30,14 +50,26 @@ bluesky-comments:
 
 {{< bluesky-comments https://bsky.app/profile/grrrck.xyz/post/3lbu5opiixc2j uri="https://bsky.app/profile/coatless.bsky.social" >}}
 
+
 ## Expected
 
 When rendered, this document should produce three non-blocking errors and no comments or output will appear in the document.
 
 ```
-(E) [bluesky-comments] Post record key 3lbtwdydxrk26 provided but `bluesky-comments.profile` metadata is not set.
-(E) [bluesky-comments] Shortcode requires the Bluesky post URL, AT-proto URI, or post record key as an unnamed argument.
-(E) [bluesky-comments] Cannot provide both named and unnamed arguments for post URI:
+ERROR (/..snip../_extensions/bluesky-comments/utils.lua:9)
+[bluesky-comments] Post record key 3lbtwdydxrk26 provided but `bluesky-comments.profile` metadata is not set.
+
+ERROR (/..snip../_extensions/bluesky-comments/utils.lua:9)
+[bluesky-comments] Shortcode requires the Bluesky post URL, AT-proto URI, or post record key as an unnamed argument.
+
+ERROR (/..snip../_extensions/bluesky-comments/utils.lua:9)
+[bluesky-comments] Invalid Bluesky URL format: https://example.com/bad/
+
+ERROR (/..snip../_extensions/bluesky-comments/utils.lua:9)
+[bluesky-comments] Failed to resolve handle 'bad.bad.bad.bad.bad'. InvalidRequest: Unable to resolve handle
+
+ERROR (/..snip../_extensions/bluesky-comments/utils.lua:9)
+[bluesky-comments] Cannot provide both named and unnamed arguments for post URI:
     * uri="https://bsky.app/profile/coatless.bsky.social"
     * https://bsky.app/profile/grrrck.xyz/post/3lbu5opiixc2j
 ```


### PR DESCRIPTION
This doesn't make `{{< bluesky-comments >}}` errors stop `quarto render` but it does make the errors more visible and it consolidates our error handling logic so that we can make the change in the future from one place.

The primary reason I don't want to have errors break `quarto render` is that at this point there isn't a way to exit a shortcode while signaling to quarto the errors was handled and quarto should exit gracefully. I talked with the Quarto team internally today and it sounds like this is something that is likely to happen in the future. They also indicated that we should avoid stopping an in-progress `quarto render`.

My initial reason for not halting is that if we use `assert(false, "bad things happened")` we'll get a full stack trace, but this mostly includes Quarto's shortcode handling code and adds dozens of lines of noise. Stopping would be better early on, but the experience is so much worse because the stack trace really obfuscates the error.

After the conversation with the Quarto team, another reason for not throwing emerged. Quarto plans to improve render speed and orchestration in the relatively near future. If, during that process, as is likely, they parallelize render operations, our halting the render would break Quarto's ability to manage the orchestration.

At this time, I'd rather wait for a Quarto-native level of support and for us to be able to cleanly communicate the shortcode failures to Quarto.

At least this PR makes it easier for us to update in the future to make use of those kinds of facilities.