### PR TITLE
Bump to new dev version v0.1.0-dev0

### DIFF
--- a/_extensions/bluesky-comments/_extension.yml
+++ b/_extensions/bluesky-comments/_extension.yml
@@ -1,6 +1,6 @@
 title: bluesky-comments
 author: James Joseph Balamuta, Garrick Aden-Buie
-version: 0.0.0-dev.2
+version: 0.1.0-dev0
 quarto-required: ">=1.5.0"
 contributes:
   shortcodes:


### PR DESCRIPTION
I meant to bump to a new dev version earlier. I'm using the versioning common Python of `{next_version}.dev{distance}`. So `0.1.0-dev0` indicates it's the dev version of what will be released as `0.1.0`. We can bump the dev distance as needed.
