### PR TITLE
feat: Update post links

### DIFF
--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -370,6 +370,7 @@ class BlueskyComments extends HTMLElement {
     ` : '';
 
     const contentHtml = `
+      <h2>Comments</h2>
       <div class="stats">
         <a href="${postUrl}" target="_blank">
           <span>♡ ${this.thread.post.likeCount || 0} likes</span>
@@ -377,7 +378,6 @@ class BlueskyComments extends HTMLElement {
           <span>💬 ${this.thread.post.replyCount || 0} replies</span>
         </a>
       </div>
-      <h2>Comments</h2>
       ${filteredCount > 0 ?
         `<p class="filtered-notice">
           ${filteredCount} ${filteredCount === 1 ? 'comment has' : 'comments have'} been filtered based on moderation settings.

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -376,7 +376,7 @@ class BlueskyComments extends HTMLElement {
           ${filteredCount} ${filteredCount === 1 ? 'comment has' : 'comments have'} been filtered based on moderation settings.
           </p>` : ''}
       <p class="reply-prompt">
-        Reply on Bluesky <a href="${postUrl}" target="_blank">here</a> to join the conversation.
+        <a href="${postUrl}" target="_blank">Reply on Bluesky</a> to join the conversation.
       </p>
       <hr/>
       <div class="comments-list">

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -267,6 +267,8 @@ class BlueskyComments extends HTMLElement {
       </div>
     ` : '';
 
+    const postId = comment.post.uri.split("/").pop()
+
     return `
       <div class="comment" id="comment-${commentId}">
         ${warningHtml}
@@ -276,6 +278,11 @@ class BlueskyComments extends HTMLElement {
               ${avatarHtml}
               <span>${author.displayName || author.handle}</span>
               <span class="handle">@${author.handle}</span>
+            </a>
+            <a href="https://bsky.app/profile/${author.did}/post/${postId}"
+               class="timestamp-link"
+               target="_blank">
+              ${this.#formatTimestamp(comment.post.record.createdAt)}
             </a>
           </div>
           <div class="comment-body">
@@ -425,6 +432,18 @@ class BlueskyComments extends HTMLElement {
   showMore() {
     this.currentVisibleCount += this.config.visibleComments;
     this.render();
+  }
+
+  #formatTimestamp(isoString) {
+    const date = new Date(isoString);
+    return date.toLocaleDateString(navigator.language || 'en-US', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true
+    });
   }
 }
 

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -35,7 +35,20 @@
 }
 
 .comment-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
   margin-bottom: 0.5rem;
+}
+
+.timestamp-link {
+  color: var(--bs-tertiary-color, #666);
+  font-size: 0.9rem;
+  text-decoration: none;
+}
+
+.timestamp-link:hover {
+  text-decoration: underline;
 }
 
 .filtered-notice {


### PR DESCRIPTION
1. Make "reply on bluesky" the link target
2. Move "comments" header above stats so that its above entire comments section
3. Add a timestamp that links directly back to the post

![image](https://github.com/user-attachments/assets/6e4f15f9-63bd-40bd-aa0e-e9cfcec93371)
