### PR TITLE
feat: stats icons, quotes, and links

### DIFF
--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -379,10 +379,14 @@ class BlueskyComments extends HTMLElement {
     const contentHtml = `
       <h2>Comments</h2>
       <div class="stats">
-        <a href="${postUrl}" target="_blank">
-            <span class="action-item">${this.statsIcons.likes} ${this.thread.post.likeCount || 0}</span>
-            <span class="action-item">${this.statsIcons.reposts} ${this.thread.post.repostCount || 0}</span>
-            <span class="action-item">${this.statsIcons.quotes} ${this.thread.post.replyCount || 0}</span>
+        <a href="${postUrl}/likes" target="_blank" class="stat-link">
+          <span class="action-item">${this.statsIcons.likes} ${this.thread.post.likeCount || 0}</span>
+        </a>
+        <a href="${postUrl}/repost" target="_blank" class="stat-link">
+          <span class="action-item">${this.statsIcons.reposts} ${this.thread.post.repostCount || 0}</span>
+        </a>
+        <a href="${postUrl}/quotes" target="_blank" class="stat-link">
+          <span class="action-item">${this.statsIcons.quotes} ${this.thread.post.replyCount || 0}</span>
         </a>
       </div>
       ${filteredCount > 0 ?

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -21,7 +21,8 @@ class BlueskyComments extends HTMLElement {
     this.statsIcons = {
       likes: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-pink, pink)" class="bi bi-heart-fill" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 1.314C12.438-3.248 23.534 4.735 8 15-7.534 4.736 3.562-3.248 8 1.314"/></svg>',
       reposts: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-green, green)" class="bi bi-recycle" viewBox="0 0 16 16"><path d="M9.302 1.256a1.5 1.5 0 0 0-2.604 0l-1.704 2.98a.5.5 0 0 0 .869.497l1.703-2.981a.5.5 0 0 1 .868 0l2.54 4.444-1.256-.337a.5.5 0 1 0-.26.966l2.415.647a.5.5 0 0 0 .613-.353l.647-2.415a.5.5 0 1 0-.966-.259l-.333 1.242zM2.973 7.773l-1.255.337a.5.5 0 1 1-.26-.966l2.416-.647a.5.5 0 0 1 .612.353l.647 2.415a.5.5 0 0 1-.966.259l-.333-1.242-2.545 4.454a.5.5 0 0 0 .434.748H5a.5.5 0 0 1 0 1H1.723A1.5 1.5 0 0 1 .421 12.24zm10.89 1.463a.5.5 0 1 0-.868.496l1.716 3.004a.5.5 0 0 1-.434.748h-5.57l.647-.646a.5.5 0 1 0-.708-.707l-1.5 1.5a.5.5 0 0 0 0 .707l1.5 1.5a.5.5 0 1 0 .708-.707l-.647-.647h5.57a1.5 1.5 0 0 0 1.302-2.244z"/></svg>',
-      quotes: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-blue, blue)" class="bi bi-chat-dots-fill" viewBox="0 0 16 16"><path d="M16 8c0 3.866-3.582 7-8 7a9 9 0 0 1-2.347-.306c-.584.296-1.925.864-4.181 1.234-.2.032-.352-.176-.273-.362.354-.836.674-1.95.77-2.966C.744 11.37 0 9.76 0 8c0-3.866 3.582-7 8-7s8 3.134 8 7M5 8a1 1 0 1 0-2 0 1 1 0 0 0 2 0m4 0a1 1 0 1 0-2 0 1 1 0 0 0 2 0m3 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2"/></svg>'
+      replies: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-blue, blue)" class="bi bi-chat-dots-fill" viewBox="0 0 16 16"><path d="M16 8c0 3.866-3.582 7-8 7a9 9 0 0 1-2.347-.306c-.584.296-1.925.864-4.181 1.234-.2.032-.352-.176-.273-.362.354-.836.674-1.95.77-2.966C.744 11.37 0 9.76 0 8c0-3.866 3.582-7 8-7s8 3.134 8 7M5 8a1 1 0 1 0-2 0 1 1 0 0 0 2 0m4 0a1 1 0 1 0-2 0 1 1 0 0 0 2 0m3 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2"/></svg>',
+      quotes: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-purple, purple)" class="bi bi-quote" viewBox="0 0 16 16"><path d="M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z"/></svg>'
     };
 
     // Bind methods
@@ -253,6 +254,9 @@ class BlueskyComments extends HTMLElement {
     const hasWarning = labels.length > 0 && !this.acknowledgedWarnings.has(warningType);
     const warningId = hasWarning ? `warning-${commentId}` : '';
 
+    const postId = comment.post.uri.split("/").pop();
+    const postUrl = `https://bsky.app/profile/${author.did}/post/${postId}`;
+
     const warningHtml = hasWarning ? `
       <div class="content-warning">
         <div class="warning-content">
@@ -274,8 +278,6 @@ class BlueskyComments extends HTMLElement {
       </div>
     ` : '';
 
-    const postId = comment.post.uri.split("/").pop()
-
     return `
       <div class="comment" id="comment-${commentId}">
         ${warningHtml}
@@ -286,7 +288,7 @@ class BlueskyComments extends HTMLElement {
               <span>${author.displayName || author.handle}</span>
               <span class="handle">@${author.handle}</span>
             </a>
-            <a href="https://bsky.app/profile/${author.did}/post/${postId}"
+            <a href="${postUrl}"
                class="timestamp-link"
                target="_blank">
               ${this.#formatTimestamp(comment.post.record.createdAt)}
@@ -295,9 +297,18 @@ class BlueskyComments extends HTMLElement {
           <div class="comment-body">
             <p>${comment.post.record.text}</p>
             <div class="comment-actions">
-              <span class="action-item">${this.statsIcons.likes} ${comment.post.likeCount || 0}</span>
-              <span class="action-item">${this.statsIcons.reposts} ${comment.post.repostCount || 0}</span>
-              <span class="action-item">${this.statsIcons.quotes} ${comment.post.replyCount || 0}</span>
+              <a href="${postUrl}/liked-by" target="_blank" class="action-link">
+                <span class="action-item">${this.statsIcons.likes} ${comment.post.likeCount || 0}</span>
+              </a>
+              <a href="${postUrl}/reposted-by" target="_blank" class="action-link">
+                <span class="action-item">${this.statsIcons.reposts} ${comment.post.repostCount || 0}</span>
+              </a>
+              <a href="${postUrl}/quotes" target="_blank" class="action-link">
+                <span class="action-item">${this.statsIcons.quotes} ${comment.post.quoteCount || 0}</span>
+              </a>
+              <a href="${postUrl}" target="_blank" class="action-link">
+                <span class="action-item">${this.statsIcons.replies} ${comment.post.replyCount || 0}</span>
+              </a>
             </div>
           </div>
           ${this.renderReplies(visibleReplies, depth + 1)}
@@ -379,14 +390,17 @@ class BlueskyComments extends HTMLElement {
     const contentHtml = `
       <h2>Comments</h2>
       <div class="stats">
-        <a href="${postUrl}/likes" target="_blank" class="stat-link">
+        <a href="${postUrl}/liked-by" target="_blank" class="stat-link">
           <span class="action-item">${this.statsIcons.likes} ${this.thread.post.likeCount || 0}</span>
         </a>
-        <a href="${postUrl}/repost" target="_blank" class="stat-link">
+        <a href="${postUrl}/reposted-by" target="_blank" class="stat-link">
           <span class="action-item">${this.statsIcons.reposts} ${this.thread.post.repostCount || 0}</span>
         </a>
         <a href="${postUrl}/quotes" target="_blank" class="stat-link">
-          <span class="action-item">${this.statsIcons.quotes} ${this.thread.post.replyCount || 0}</span>
+          <span class="action-item">${this.statsIcons.quotes} ${this.thread.post.quoteCount || 0}</span>
+        </a>
+        <a href="${postUrl}" target="_blank" class="stat-link">
+          <span class="action-item">${this.statsIcons.replies} ${this.thread.post.replyCount || 0}</span>
         </a>
       </div>
       ${filteredCount > 0 ?

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -17,6 +17,13 @@ class BlueskyComments extends HTMLElement {
     this.replyVisibilityCounts = new Map();
     this.acknowledgedWarnings = new Set();
 
+    // Define SVG icons
+    this.statsIcons = {
+      likes: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-pink, pink)" class="bi bi-heart-fill" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 1.314C12.438-3.248 23.534 4.735 8 15-7.534 4.736 3.562-3.248 8 1.314"/></svg>',
+      reposts: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-green, green)" class="bi bi-recycle" viewBox="0 0 16 16"><path d="M9.302 1.256a1.5 1.5 0 0 0-2.604 0l-1.704 2.98a.5.5 0 0 0 .869.497l1.703-2.981a.5.5 0 0 1 .868 0l2.54 4.444-1.256-.337a.5.5 0 1 0-.26.966l2.415.647a.5.5 0 0 0 .613-.353l.647-2.415a.5.5 0 1 0-.966-.259l-.333 1.242zM2.973 7.773l-1.255.337a.5.5 0 1 1-.26-.966l2.416-.647a.5.5 0 0 1 .612.353l.647 2.415a.5.5 0 0 1-.966.259l-.333-1.242-2.545 4.454a.5.5 0 0 0 .434.748H5a.5.5 0 0 1 0 1H1.723A1.5 1.5 0 0 1 .421 12.24zm10.89 1.463a.5.5 0 1 0-.868.496l1.716 3.004a.5.5 0 0 1-.434.748h-5.57l.647-.646a.5.5 0 1 0-.708-.707l-1.5 1.5a.5.5 0 0 0 0 .707l1.5 1.5a.5.5 0 1 0 .708-.707l-.647-.647h5.57a1.5 1.5 0 0 0 1.302-2.244z"/></svg>',
+      quotes: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-blue, blue)" class="bi bi-chat-dots-fill" viewBox="0 0 16 16"><path d="M16 8c0 3.866-3.582 7-8 7a9 9 0 0 1-2.347-.306c-.584.296-1.925.864-4.181 1.234-.2.032-.352-.176-.273-.362.354-.836.674-1.95.77-2.966C.744 11.37 0 9.76 0 8c0-3.866 3.582-7 8-7s8 3.134 8 7M5 8a1 1 0 1 0-2 0 1 1 0 0 0 2 0m4 0a1 1 0 1 0-2 0 1 1 0 0 0 2 0m3 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2"/></svg>'
+    };
+
     // Bind methods
     this.showMore = this.showMore.bind(this);
     this.showMoreReplies = this.showMoreReplies.bind(this);
@@ -288,9 +295,9 @@ class BlueskyComments extends HTMLElement {
           <div class="comment-body">
             <p>${comment.post.record.text}</p>
             <div class="comment-actions">
-              <span>♡ ${comment.post.likeCount || 0}</span>
-              <span>↻ ${comment.post.repostCount || 0}</span>
-              <span>💬 ${comment.post.replyCount || 0}</span>
+              <span class="action-item">${this.statsIcons.likes} ${comment.post.likeCount || 0}</span>
+              <span class="action-item">${this.statsIcons.reposts} ${comment.post.repostCount || 0}</span>
+              <span class="action-item">${this.statsIcons.quotes} ${comment.post.replyCount || 0}</span>
             </div>
           </div>
           ${this.renderReplies(visibleReplies, depth + 1)}
@@ -373,9 +380,9 @@ class BlueskyComments extends HTMLElement {
       <h2>Comments</h2>
       <div class="stats">
         <a href="${postUrl}" target="_blank">
-          <span>♡ ${this.thread.post.likeCount || 0} likes</span>
-          <span>↻ ${this.thread.post.repostCount || 0} reposts</span>
-          <span>💬 ${this.thread.post.replyCount || 0} replies</span>
+            <span class="action-item">${this.statsIcons.likes} ${this.thread.post.likeCount || 0}</span>
+            <span class="action-item">${this.statsIcons.reposts} ${this.thread.post.repostCount || 0}</span>
+            <span class="action-item">${this.statsIcons.quotes} ${this.thread.post.replyCount || 0}</span>
         </a>
       </div>
       ${filteredCount > 0 ?

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -298,16 +298,28 @@ class BlueskyComments extends HTMLElement {
             <p>${comment.post.record.text}</p>
             <div class="comment-actions">
               <a href="${postUrl}/liked-by" target="_blank" class="action-link">
-                <span class="action-item">${this.statsIcons.likes} ${comment.post.likeCount || 0}</span>
+                <span class="action-item">
+                  ${this.statsIcons.likes}
+                  <span class="action-text">${comment.post.likeCount || 0} likes</span>
+                </span>
               </a>
               <a href="${postUrl}/reposted-by" target="_blank" class="action-link">
-                <span class="action-item">${this.statsIcons.reposts} ${comment.post.repostCount || 0}</span>
-              </a>
-              <a href="${postUrl}/quotes" target="_blank" class="action-link">
-                <span class="action-item">${this.statsIcons.quotes} ${comment.post.quoteCount || 0}</span>
+                <span class="action-item">
+                  ${this.statsIcons.reposts}
+                  <span class="action-text">${comment.post.repostCount || 0} reposts</span>
+                </span>
               </a>
               <a href="${postUrl}" target="_blank" class="action-link">
-                <span class="action-item">${this.statsIcons.replies} ${comment.post.replyCount || 0}</span>
+                <span class="action-item">
+                  ${this.statsIcons.replies}
+                  <span class="action-text">${comment.post.replyCount || 0} replies</span>
+                </span>
+              </a>
+              <a href="${postUrl}/quoted-by" target="_blank" class="action-link">
+                <span class="action-item">
+                  ${this.statsIcons.quotes}
+                  <span class="action-text">${comment.post.quoteCount || 0} quotes</span>
+                </span>
               </a>
             </div>
           </div>
@@ -389,20 +401,32 @@ class BlueskyComments extends HTMLElement {
 
     const contentHtml = `
       <h2>Comments</h2>
-      <div class="stats">
-        <a href="${postUrl}/liked-by" target="_blank" class="stat-link">
-          <span class="action-item">${this.statsIcons.likes} ${this.thread.post.likeCount || 0}</span>
-        </a>
-        <a href="${postUrl}/reposted-by" target="_blank" class="stat-link">
-          <span class="action-item">${this.statsIcons.reposts} ${this.thread.post.repostCount || 0}</span>
-        </a>
-        <a href="${postUrl}/quotes" target="_blank" class="stat-link">
-          <span class="action-item">${this.statsIcons.quotes} ${this.thread.post.quoteCount || 0}</span>
-        </a>
-        <a href="${postUrl}" target="_blank" class="stat-link">
-          <span class="action-item">${this.statsIcons.replies} ${this.thread.post.replyCount || 0}</span>
-        </a>
-      </div>
+        <div class="stats">
+          <a href="${postUrl}/liked-by" target="_blank" class="stat-link">
+            <span class="action-item">
+              ${this.statsIcons.likes}
+              <span class="action-text">${this.thread.post.likeCount || 0} likes</span>
+            </span>
+          </a>
+          <a href="${postUrl}/reposted-by" target="_blank" class="stat-link">
+            <span class="action-item">
+              ${this.statsIcons.reposts}
+              <span class="action-text">${this.thread.post.repostCount || 0} reposts</span>
+            </span>
+          </a>
+          <a href="${postUrl}" target="_blank" class="stat-link">
+            <span class="action-item">
+              ${this.statsIcons.replies}
+              <span class="action-text">${this.thread.post.replyCount || 0} replies</span>
+            </span>
+          </a>
+          <a href="${postUrl}/quoted-by" target="_blank" class="stat-link">
+            <span class="action-item">
+              ${this.statsIcons.quotes}
+              <span class="action-text">${this.thread.post.quoteCount || 0} quotes</span>
+            </span>
+          </a>
+        </div>
       ${filteredCount > 0 ?
         `<p class="filtered-notice">
           ${filteredCount} ${filteredCount === 1 ? 'comment has' : 'comments have'} been filtered based on moderation settings.

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -21,6 +21,17 @@
   text-decoration: underline;
 }
 
+.action-item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.action-item svg {
+  height: 1em;
+  width: 1em;
+}
+
 .avatar, .avatar-placeholder {
   width: 24px;
   height: 24px;

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -31,6 +31,10 @@
   opacity: 0.8;
 }
 
+.action-text {
+  white-space: nowrap;
+}
+
 .action-item {
   display: flex;
   align-items: center;
@@ -40,6 +44,7 @@
 .action-item svg {
   height: 1em;
   width: 1em;
+  flex-shrink: 0;
 }
 
 .avatar, .avatar-placeholder {

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -21,6 +21,16 @@
   text-decoration: underline;
 }
 
+.stat-link {
+  text-decoration: none;
+  color: inherit;
+  transition: opacity 0.2s;
+}
+
+.stat-link:hover {
+  opacity: 0.8;
+}
+
 .action-item {
   display: flex;
   align-items: center;

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -17,17 +17,17 @@
   color: inherit;
 }
 
-.stats a:hover {
+.stats a:hover, .comment-actions a:hover {
   text-decoration: underline;
 }
 
-.stat-link {
+.stat-link, .action-link {
   text-decoration: none;
   color: inherit;
   transition: opacity 0.2s;
 }
 
-.stat-link:hover {
+.stat-link:hover, .action-link:hover {
   opacity: 0.8;
 }
 
@@ -61,6 +61,14 @@
   gap: 0.25rem;
   margin-bottom: 0.5rem;
 }
+
+
+.comment-actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
 
 .timestamp-link {
   color: var(--bs-tertiary-color, #666);


### PR DESCRIPTION
This PR implements:

1. SVG icons as part of the initial class construction instead of using system emoji
2. Separated "quotes" and "repost" counts (since we can redirect to different pages on a given post).
3. For links, we use:
    - `/liked-by` for **likes**
    - `/reposted-by` for **reposts**
    - Just the post URL for **replies** (they show in the thread view)
    - `/quotes` for **quotes**

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="769" alt="Before implementation of SVG icons and quotes" src="https://github.com/user-attachments/assets/4249f4f4-ebfe-422b-9763-d60ad6c48be5" /></td>
    <td><img width="657" alt="After implementation of SVG icons and quotes" src="https://github.com/user-attachments/assets/518aebde-26e8-42b5-b33a-522745f2ad18" />
</td>
  </tr>
</table>



Close #19 
Close #18
Close #17 
