### PR TITLE
refactor: Stats bar and comment layout improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ You may specify these variables in your document's CSS or in a custom CSS file u
 | `--bc-thread-line` | Reply thread lines | `var(--bs-border-color)` |
 | `--bc-warning-text` | Warning text | `var(--bs-danger)` |
 | `--bc-warning-button` | Warning button | `var(--bs-primary)` |
+| `--bc-avatar-size` | Avatar size | `24px` |
 
 
 ## Limitations

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -288,8 +288,8 @@ class BlueskyComments extends HTMLElement {
         ${warningHtml}
         <div id="${warningId}" style="display: ${hasWarning ? 'none' : 'block'}">
           <div class="comment-header">
+            ${avatarHtml}
             <a href="https://bsky.app/profile/${author.did}" target="_blank" class="author-link">
-              ${avatarHtml}
               <span>${author.displayName || author.handle}</span>
               <span class="handle">@${author.handle}</span>
             </a>

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -387,7 +387,6 @@ class BlueskyComments extends HTMLElement {
       <p class="reply-prompt">
         <a href="${postUrl}" target="_blank">Reply on Bluesky</a> to join the conversation.
       </p>
-      <hr/>
       <div class="comments-list">
         ${visibleReplies.map(reply => this.renderComment(reply, 0)).join('')}
       </div>

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -301,7 +301,7 @@ class BlueskyComments extends HTMLElement {
           </div>
           <div class="comment-body">
             <p>${comment.post.record.text}</p>
-            <div class="comment-actions">${this.#postStatsBar(comment.post, {postUrl, showIcons: false})}</div>
+            <div class="comment-stats">${this.#postStatsBar(comment.post, {postUrl, showIcons: false})}</div>
           </div>
           ${this.renderReplies(visibleReplies, depth + 1)}
           ${hiddenReplies.length > 0 ?

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -30,6 +30,11 @@ class BlueskyComments extends HTMLElement {
     this.showMoreReplies = this.showMoreReplies.bind(this);
   }
 
+  get postUrl() {
+    const [, , did, , rkey] = this.getAttribute('post').split('/');
+    return `https://bsky.app/profile/${did}/post/${rkey}`;
+  }
+
   static get observedAttributes() {
     return ['post'];
   }
@@ -357,8 +362,7 @@ class BlueskyComments extends HTMLElement {
       return;
     }
 
-    const [, , did, , rkey] = this.getAttribute('post').split('/');
-    const postUrl = `https://bsky.app/profile/${did}/post/${rkey}`;
+    const postUrl = this.postUrl
 
     // Filter and sort replies
     const labels = this.thread.post.labels?.map(l => ({
@@ -401,32 +405,7 @@ class BlueskyComments extends HTMLElement {
 
     const contentHtml = `
       <h2>Comments</h2>
-        <div class="stats">
-          <a href="${postUrl}/liked-by" target="_blank" class="stat-link">
-            <span class="action-item">
-              ${this.statsIcons.likes}
-              <span class="action-text">${this.thread.post.likeCount || 0} likes</span>
-            </span>
-          </a>
-          <a href="${postUrl}" target="_blank" class="stat-link">
-            <span class="action-item">
-              ${this.statsIcons.replies}
-              <span class="action-text">${this.thread.post.replyCount || 0} replies</span>
-            </span>
-          </a>
-          <a href="${postUrl}/reposted-by" target="_blank" class="stat-link">
-            <span class="action-item">
-              ${this.statsIcons.reposts}
-              <span class="action-text">${this.thread.post.repostCount || 0} reposts</span>
-            </span>
-          </a>
-          <a href="${postUrl}/quoted-by" target="_blank" class="stat-link">
-            <span class="action-item">
-              ${this.statsIcons.quotes}
-              <span class="action-text">${this.thread.post.quoteCount || 0} quotes</span>
-            </span>
-          </a>
-        </div>
+      <div class="stats">${this.#postStatsBar(this.thread.post)}</div>
       ${filteredCount > 0 ?
         `<p class="filtered-notice">
           ${filteredCount} ${filteredCount === 1 ? 'comment has' : 'comments have'} been filtered based on moderation settings.
@@ -476,6 +455,33 @@ class BlueskyComments extends HTMLElement {
     this.querySelectorAll('.show-more-replies').forEach(button => {
       button.addEventListener('click', this.showMoreReplies);
     });
+  }
+
+  #postStatsBar(post) {
+    return `<a href="${this.postUrl}/liked-by" target="_blank" class="stat-link">
+        <span class="action-item">
+          ${this.statsIcons.likes}
+          <span class="action-text">${post.likeCount || 0} likes</span>
+        </span>
+      </a>
+      <a href="${this.postUrl}" target="_blank" class="stat-link">
+        <span class="action-item">
+          ${this.statsIcons.replies}
+          <span class="action-text">${post.replyCount || 0} replies</span>
+        </span>
+      </a>
+      <a href="${this.postUrl}/reposted-by" target="_blank" class="stat-link">
+        <span class="action-item">
+          ${this.statsIcons.reposts}
+          <span class="action-text">${post.repostCount || 0} reposts</span>
+        </span>
+      </a>
+      <a href="${this.postUrl}/quoted-by" target="_blank" class="stat-link">
+        <span class="action-item">
+          ${this.statsIcons.quotes}
+          <span class="action-text">${post.quoteCount || 0} quotes</span>
+        </span>
+      </a>`
   }
 
   showMore() {

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -19,10 +19,10 @@ class BlueskyComments extends HTMLElement {
 
     // Define SVG icons
     this.statsIcons = {
-      likes: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-pink, pink)" class="bi bi-heart-fill" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 1.314C12.438-3.248 23.534 4.735 8 15-7.534 4.736 3.562-3.248 8 1.314"/></svg>',
-      reposts: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-green, green)" class="bi bi-recycle" viewBox="0 0 16 16"><path d="M9.302 1.256a1.5 1.5 0 0 0-2.604 0l-1.704 2.98a.5.5 0 0 0 .869.497l1.703-2.981a.5.5 0 0 1 .868 0l2.54 4.444-1.256-.337a.5.5 0 1 0-.26.966l2.415.647a.5.5 0 0 0 .613-.353l.647-2.415a.5.5 0 1 0-.966-.259l-.333 1.242zM2.973 7.773l-1.255.337a.5.5 0 1 1-.26-.966l2.416-.647a.5.5 0 0 1 .612.353l.647 2.415a.5.5 0 0 1-.966.259l-.333-1.242-2.545 4.454a.5.5 0 0 0 .434.748H5a.5.5 0 0 1 0 1H1.723A1.5 1.5 0 0 1 .421 12.24zm10.89 1.463a.5.5 0 1 0-.868.496l1.716 3.004a.5.5 0 0 1-.434.748h-5.57l.647-.646a.5.5 0 1 0-.708-.707l-1.5 1.5a.5.5 0 0 0 0 .707l1.5 1.5a.5.5 0 1 0 .708-.707l-.647-.647h5.57a1.5 1.5 0 0 0 1.302-2.244z"/></svg>',
-      replies: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-blue, blue)" class="bi bi-chat-dots-fill" viewBox="0 0 16 16"><path d="M16 8c0 3.866-3.582 7-8 7a9 9 0 0 1-2.347-.306c-.584.296-1.925.864-4.181 1.234-.2.032-.352-.176-.273-.362.354-.836.674-1.95.77-2.966C.744 11.37 0 9.76 0 8c0-3.866 3.582-7 8-7s8 3.134 8 7M5 8a1 1 0 1 0-2 0 1 1 0 0 0 2 0m4 0a1 1 0 1 0-2 0 1 1 0 0 0 2 0m3 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2"/></svg>',
-      quotes: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-purple, purple)" class="bi bi-quote" viewBox="0 0 16 16"><path d="M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z"/></svg>'
+      like: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-pink, pink)" class="bi bi-heart-fill" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 1.314C12.438-3.248 23.534 4.735 8 15-7.534 4.736 3.562-3.248 8 1.314"/></svg>',
+      repost: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-green, green)" class="bi bi-recycle" viewBox="0 0 16 16"><path d="M9.302 1.256a1.5 1.5 0 0 0-2.604 0l-1.704 2.98a.5.5 0 0 0 .869.497l1.703-2.981a.5.5 0 0 1 .868 0l2.54 4.444-1.256-.337a.5.5 0 1 0-.26.966l2.415.647a.5.5 0 0 0 .613-.353l.647-2.415a.5.5 0 1 0-.966-.259l-.333 1.242zM2.973 7.773l-1.255.337a.5.5 0 1 1-.26-.966l2.416-.647a.5.5 0 0 1 .612.353l.647 2.415a.5.5 0 0 1-.966.259l-.333-1.242-2.545 4.454a.5.5 0 0 0 .434.748H5a.5.5 0 0 1 0 1H1.723A1.5 1.5 0 0 1 .421 12.24zm10.89 1.463a.5.5 0 1 0-.868.496l1.716 3.004a.5.5 0 0 1-.434.748h-5.57l.647-.646a.5.5 0 1 0-.708-.707l-1.5 1.5a.5.5 0 0 0 0 .707l1.5 1.5a.5.5 0 1 0 .708-.707l-.647-.647h5.57a1.5 1.5 0 0 0 1.302-2.244z"/></svg>',
+      reply: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-blue, blue)" class="bi bi-chat-dots-fill" viewBox="0 0 16 16"><path d="M16 8c0 3.866-3.582 7-8 7a9 9 0 0 1-2.347-.306c-.584.296-1.925.864-4.181 1.234-.2.032-.352-.176-.273-.362.354-.836.674-1.95.77-2.966C.744 11.37 0 9.76 0 8c0-3.866 3.582-7 8-7s8 3.134 8 7M5 8a1 1 0 1 0-2 0 1 1 0 0 0 2 0m4 0a1 1 0 1 0-2 0 1 1 0 0 0 2 0m3 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2"/></svg>',
+      quote: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-purple, purple)" class="bi bi-quote" viewBox="0 0 16 16"><path d="M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z"/></svg>'
     };
 
     // Bind methods
@@ -301,7 +301,7 @@ class BlueskyComments extends HTMLElement {
           </div>
           <div class="comment-body">
             <p>${comment.post.record.text}</p>
-            <div class="comment-stats">${this.#postStatsBar(comment.post, {postUrl, showIcons: false})}</div>
+            <div class="comment-stats">${this.#postStatsBar(comment.post, {postUrl, showIcons: false, showZero: false})}</div>
           </div>
           ${this.renderReplies(visibleReplies, depth + 1)}
           ${hiddenReplies.length > 0 ?
@@ -432,7 +432,7 @@ class BlueskyComments extends HTMLElement {
     });
   }
 
-  #postStatsBar(post, {postUrl, showIcons} = {showIcons: true}) {
+  #postStatsBar(post, {postUrl, showIcons, showZero} = {showIcons: true, showZero: true}) {
     postUrl = postUrl || this.postUrl;
 
     const plurals = {
@@ -440,41 +440,38 @@ class BlueskyComments extends HTMLElement {
       reply: "replies",
       repost: "reposts",
       quote: "quotes"
-    }
+    };
+
+    const bskyPaths = {
+      like: "/liked-by",
+      reply: "",
+      repost: "/reposted-by",
+      quote: "/quoted-by"
+    };
 
     const stats = {};
-    ['like', 'reply', 'repost', 'quote'].forEach((type) => {
+    Object.keys(plurals).forEach((type) => {
       const count = post[`${type}Count`] || 0
       stats[type] = {
         count,
         text: count == 1 ? type : plurals[type]
       }
+    });
+
+    const statsHtml = Object.keys(plurals).map((type) => {
+      if (stats[type].count == 0 && !showZero) {
+        return '';
+      }
+
+      return `<a href="${postUrl}${bskyPaths[type]}" target="_blank" class="stat-link">
+        <span class="action-item">
+          ${showIcons ? this.statsIcons[type] : ''}
+          <span class="action-text">${stats[type].count} ${stats[type].text}</span>
+        </span>
+      </a>`;
     })
 
-    return `<a href="${postUrl}/liked-by" target="_blank" class="stat-link">
-        <span class="action-item">
-          ${showIcons ? this.statsIcons.likes : ''}
-          <span class="action-text">${stats.like.count} ${stats.like.text}</span>
-        </span>
-      </a>
-      <a href="${postUrl}" target="_blank" class="stat-link">
-        <span class="action-item">
-          ${showIcons ? this.statsIcons.replies : ''}
-          <span class="action-text">${stats.reply.count} ${stats.reply.text}</span>
-        </span>
-      </a>
-      <a href="${postUrl}/reposted-by" target="_blank" class="stat-link">
-        <span class="action-item">
-          ${showIcons ? this.statsIcons.reposts : ''}
-          <span class="action-text">${stats.repost.count} ${stats.repost.text}</span>
-        </span>
-      </a>
-      <a href="${postUrl}/quoted-by" target="_blank" class="stat-link">
-        <span class="action-item">
-          ${showIcons ? this.statsIcons.quotes : ''}
-          <span class="action-text">${stats.quote.count} ${stats.quote.text}</span>
-        </span>
-      </a>`
+    return statsHtml.join('\n');
   }
 
   showMore() {

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -17,14 +17,6 @@ class BlueskyComments extends HTMLElement {
     this.replyVisibilityCounts = new Map();
     this.acknowledgedWarnings = new Set();
 
-    // Define SVG icons
-    this.statsIcons = {
-      like: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-pink, pink)" class="bi bi-heart-fill" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 1.314C12.438-3.248 23.534 4.735 8 15-7.534 4.736 3.562-3.248 8 1.314"/></svg>',
-      repost: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-green, green)" class="bi bi-recycle" viewBox="0 0 16 16"><path d="M9.302 1.256a1.5 1.5 0 0 0-2.604 0l-1.704 2.98a.5.5 0 0 0 .869.497l1.703-2.981a.5.5 0 0 1 .868 0l2.54 4.444-1.256-.337a.5.5 0 1 0-.26.966l2.415.647a.5.5 0 0 0 .613-.353l.647-2.415a.5.5 0 1 0-.966-.259l-.333 1.242zM2.973 7.773l-1.255.337a.5.5 0 1 1-.26-.966l2.416-.647a.5.5 0 0 1 .612.353l.647 2.415a.5.5 0 0 1-.966.259l-.333-1.242-2.545 4.454a.5.5 0 0 0 .434.748H5a.5.5 0 0 1 0 1H1.723A1.5 1.5 0 0 1 .421 12.24zm10.89 1.463a.5.5 0 1 0-.868.496l1.716 3.004a.5.5 0 0 1-.434.748h-5.57l.647-.646a.5.5 0 1 0-.708-.707l-1.5 1.5a.5.5 0 0 0 0 .707l1.5 1.5a.5.5 0 1 0 .708-.707l-.647-.647h5.57a1.5 1.5 0 0 0 1.302-2.244z"/></svg>',
-      reply: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-blue, blue)" class="bi bi-chat-dots-fill" viewBox="0 0 16 16"><path d="M16 8c0 3.866-3.582 7-8 7a9 9 0 0 1-2.347-.306c-.584.296-1.925.864-4.181 1.234-.2.032-.352-.176-.273-.362.354-.836.674-1.95.77-2.966C.744 11.37 0 9.76 0 8c0-3.866 3.582-7 8-7s8 3.134 8 7M5 8a1 1 0 1 0-2 0 1 1 0 0 0 2 0m4 0a1 1 0 1 0-2 0 1 1 0 0 0 2 0m3 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2"/></svg>',
-      quote: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-purple, purple)" class="bi bi-quote" viewBox="0 0 16 16"><path d="M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z"/></svg>'
-    };
-
     // Bind methods
     this.showMore = this.showMore.bind(this);
     this.showMoreReplies = this.showMoreReplies.bind(this);
@@ -488,6 +480,14 @@ class BlueskyComments extends HTMLElement {
       hour12: true
     });
   }
+
+  // Define SVG icons
+  statsIcons = {
+    like: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-pink, pink)" class="bi bi-heart-fill" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 1.314C12.438-3.248 23.534 4.735 8 15-7.534 4.736 3.562-3.248 8 1.314"/></svg>',
+    repost: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-green, green)" class="bi bi-recycle" viewBox="0 0 16 16"><path d="M9.302 1.256a1.5 1.5 0 0 0-2.604 0l-1.704 2.98a.5.5 0 0 0 .869.497l1.703-2.981a.5.5 0 0 1 .868 0l2.54 4.444-1.256-.337a.5.5 0 1 0-.26.966l2.415.647a.5.5 0 0 0 .613-.353l.647-2.415a.5.5 0 1 0-.966-.259l-.333 1.242zM2.973 7.773l-1.255.337a.5.5 0 1 1-.26-.966l2.416-.647a.5.5 0 0 1 .612.353l.647 2.415a.5.5 0 0 1-.966.259l-.333-1.242-2.545 4.454a.5.5 0 0 0 .434.748H5a.5.5 0 0 1 0 1H1.723A1.5 1.5 0 0 1 .421 12.24zm10.89 1.463a.5.5 0 1 0-.868.496l1.716 3.004a.5.5 0 0 1-.434.748h-5.57l.647-.646a.5.5 0 1 0-.708-.707l-1.5 1.5a.5.5 0 0 0 0 .707l1.5 1.5a.5.5 0 1 0 .708-.707l-.647-.647h5.57a1.5 1.5 0 0 0 1.302-2.244z"/></svg>',
+    reply: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-blue, blue)" class="bi bi-chat-dots-fill" viewBox="0 0 16 16"><path d="M16 8c0 3.866-3.582 7-8 7a9 9 0 0 1-2.347-.306c-.584.296-1.925.864-4.181 1.234-.2.032-.352-.176-.273-.362.354-.836.674-1.95.77-2.966C.744 11.37 0 9.76 0 8c0-3.866 3.582-7 8-7s8 3.134 8 7M5 8a1 1 0 1 0-2 0 1 1 0 0 0 2 0m4 0a1 1 0 1 0-2 0 1 1 0 0 0 2 0m3 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2"/></svg>',
+    quote: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="var(--bs-purple, purple)" class="bi bi-quote" viewBox="0 0 16 16"><path d="M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z"/></svg>'
+  };
 }
 
 customElements.define('bluesky-comments', BlueskyComments);

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -433,7 +433,7 @@ class BlueskyComments extends HTMLElement {
       like: "/liked-by",
       reply: "",
       repost: "/reposted-by",
-      quote: "/quoted-by"
+      quote: "/quotes"
     };
 
     const stats = {};

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -290,8 +290,7 @@ class BlueskyComments extends HTMLElement {
           <div class="comment-header">
             ${avatarHtml}
             <a href="https://bsky.app/profile/${author.did}" target="_blank" class="author-link">
-              <span>${author.displayName || author.handle}</span>
-              <span class="handle">@${author.handle}</span>
+              <span>${author.displayName || '@' + author.handle}</span>
             </a>
             <a href="${postUrl}"
                class="timestamp-link"

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -301,32 +301,7 @@ class BlueskyComments extends HTMLElement {
           </div>
           <div class="comment-body">
             <p>${comment.post.record.text}</p>
-            <div class="comment-actions">
-              <a href="${postUrl}/liked-by" target="_blank" class="action-link">
-                <span class="action-item">
-                  ${this.statsIcons.likes}
-                  <span class="action-text">${comment.post.likeCount || 0} likes</span>
-                </span>
-              </a>
-              <a href="${postUrl}" target="_blank" class="action-link">
-                <span class="action-item">
-                  ${this.statsIcons.replies}
-                  <span class="action-text">${comment.post.replyCount || 0} replies</span>
-                </span>
-              </a>
-              <a href="${postUrl}/reposted-by" target="_blank" class="action-link">
-                <span class="action-item">
-                  ${this.statsIcons.reposts}
-                  <span class="action-text">${comment.post.repostCount || 0} reposts</span>
-                </span>
-              </a>
-              <a href="${postUrl}/quoted-by" target="_blank" class="action-link">
-                <span class="action-item">
-                  ${this.statsIcons.quotes}
-                  <span class="action-text">${comment.post.quoteCount || 0} quotes</span>
-                </span>
-              </a>
-            </div>
+            <div class="comment-actions">${this.#postStatsBar(comment.post, postUrl)}</div>
           </div>
           ${this.renderReplies(visibleReplies, depth + 1)}
           ${hiddenReplies.length > 0 ?
@@ -457,26 +432,28 @@ class BlueskyComments extends HTMLElement {
     });
   }
 
-  #postStatsBar(post) {
-    return `<a href="${this.postUrl}/liked-by" target="_blank" class="stat-link">
+  #postStatsBar(post, postUrl = undefined) {
+    postUrl = postUrl || this.postUrl
+
+    return `<a href="${postUrl}/liked-by" target="_blank" class="stat-link">
         <span class="action-item">
           ${this.statsIcons.likes}
           <span class="action-text">${post.likeCount || 0} likes</span>
         </span>
       </a>
-      <a href="${this.postUrl}" target="_blank" class="stat-link">
+      <a href="${postUrl}" target="_blank" class="stat-link">
         <span class="action-item">
           ${this.statsIcons.replies}
           <span class="action-text">${post.replyCount || 0} replies</span>
         </span>
       </a>
-      <a href="${this.postUrl}/reposted-by" target="_blank" class="stat-link">
+      <a href="${postUrl}/reposted-by" target="_blank" class="stat-link">
         <span class="action-item">
           ${this.statsIcons.reposts}
           <span class="action-text">${post.repostCount || 0} reposts</span>
         </span>
       </a>
-      <a href="${this.postUrl}/quoted-by" target="_blank" class="stat-link">
+      <a href="${postUrl}/quoted-by" target="_blank" class="stat-link">
         <span class="action-item">
           ${this.statsIcons.quotes}
           <span class="action-text">${post.quoteCount || 0} quotes</span>

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -303,16 +303,16 @@ class BlueskyComments extends HTMLElement {
                   <span class="action-text">${comment.post.likeCount || 0} likes</span>
                 </span>
               </a>
-              <a href="${postUrl}/reposted-by" target="_blank" class="action-link">
-                <span class="action-item">
-                  ${this.statsIcons.reposts}
-                  <span class="action-text">${comment.post.repostCount || 0} reposts</span>
-                </span>
-              </a>
               <a href="${postUrl}" target="_blank" class="action-link">
                 <span class="action-item">
                   ${this.statsIcons.replies}
                   <span class="action-text">${comment.post.replyCount || 0} replies</span>
+                </span>
+              </a>
+              <a href="${postUrl}/reposted-by" target="_blank" class="action-link">
+                <span class="action-item">
+                  ${this.statsIcons.reposts}
+                  <span class="action-text">${comment.post.repostCount || 0} reposts</span>
                 </span>
               </a>
               <a href="${postUrl}/quoted-by" target="_blank" class="action-link">
@@ -408,16 +408,16 @@ class BlueskyComments extends HTMLElement {
               <span class="action-text">${this.thread.post.likeCount || 0} likes</span>
             </span>
           </a>
-          <a href="${postUrl}/reposted-by" target="_blank" class="stat-link">
-            <span class="action-item">
-              ${this.statsIcons.reposts}
-              <span class="action-text">${this.thread.post.repostCount || 0} reposts</span>
-            </span>
-          </a>
           <a href="${postUrl}" target="_blank" class="stat-link">
             <span class="action-item">
               ${this.statsIcons.replies}
               <span class="action-text">${this.thread.post.replyCount || 0} replies</span>
+            </span>
+          </a>
+          <a href="${postUrl}/reposted-by" target="_blank" class="stat-link">
+            <span class="action-item">
+              ${this.statsIcons.reposts}
+              <span class="action-text">${this.thread.post.repostCount || 0} reposts</span>
             </span>
           </a>
           <a href="${postUrl}/quoted-by" target="_blank" class="stat-link">

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -301,7 +301,7 @@ class BlueskyComments extends HTMLElement {
           </div>
           <div class="comment-body">
             <p>${comment.post.record.text}</p>
-            <div class="comment-actions">${this.#postStatsBar(comment.post, postUrl)}</div>
+            <div class="comment-actions">${this.#postStatsBar(comment.post, {postUrl, showIcons: false})}</div>
           </div>
           ${this.renderReplies(visibleReplies, depth + 1)}
           ${hiddenReplies.length > 0 ?
@@ -432,31 +432,47 @@ class BlueskyComments extends HTMLElement {
     });
   }
 
-  #postStatsBar(post, postUrl = undefined) {
-    postUrl = postUrl || this.postUrl
+  #postStatsBar(post, {postUrl, showIcons} = {showIcons: true}) {
+    postUrl = postUrl || this.postUrl;
+
+    const plurals = {
+      like: "likes",
+      reply: "replies",
+      repost: "reposts",
+      quote: "quotes"
+    }
+
+    const stats = {};
+    ['like', 'reply', 'repost', 'quote'].forEach((type) => {
+      const count = post[`${type}Count`] || 0
+      stats[type] = {
+        count,
+        text: count == 1 ? type : plurals[type]
+      }
+    })
 
     return `<a href="${postUrl}/liked-by" target="_blank" class="stat-link">
         <span class="action-item">
-          ${this.statsIcons.likes}
-          <span class="action-text">${post.likeCount || 0} likes</span>
+          ${showIcons ? this.statsIcons.likes : ''}
+          <span class="action-text">${stats.like.count} ${stats.like.text}</span>
         </span>
       </a>
       <a href="${postUrl}" target="_blank" class="stat-link">
         <span class="action-item">
-          ${this.statsIcons.replies}
-          <span class="action-text">${post.replyCount || 0} replies</span>
+          ${showIcons ? this.statsIcons.replies : ''}
+          <span class="action-text">${stats.reply.count} ${stats.reply.text}</span>
         </span>
       </a>
       <a href="${postUrl}/reposted-by" target="_blank" class="stat-link">
         <span class="action-item">
-          ${this.statsIcons.reposts}
-          <span class="action-text">${post.repostCount || 0} reposts</span>
+          ${showIcons ? this.statsIcons.reposts : ''}
+          <span class="action-text">${stats.repost.count} ${stats.repost.text}</span>
         </span>
       </a>
       <a href="${postUrl}/quoted-by" target="_blank" class="stat-link">
         <span class="action-item">
-          ${this.statsIcons.quotes}
-          <span class="action-text">${post.quoteCount || 0} quotes</span>
+          ${showIcons ? this.statsIcons.quotes : ''}
+          <span class="action-text">${stats.quote.count} ${stats.quote.text}</span>
         </span>
       </a>`
   }

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -388,12 +388,9 @@ class BlueskyComments extends HTMLElement {
           </button>` : ''}
     `;
 
-    this.innerHTML = `
-      <div class="bluesky-comments-container">
-        ${warningHtml}
-        <div id="${warningId}" style="display: ${hasWarning ? 'none' : 'block'}">
-          ${contentHtml}
-        </div>
+    this.innerHTML = `${warningHtml}
+      <div id="${warningId}" style="display: ${hasWarning ? 'none' : 'block'}">
+        ${contentHtml}
       </div>
     `;
 

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -122,7 +122,7 @@
  * Individual comment containers and their components */
 .comment {
   margin: 0;
-  padding-inline: 0.5rem;
+  padding-right: 0.5rem;
   padding-top: 1rem;
   border-radius: 4px;
 }
@@ -155,6 +155,10 @@
 .comment-header,
 .comment-body {
   padding-left: calc(0.5rem + var(--_avatar-size, 0) / 2);
+}
+
+.replies > .comment {
+  padding-left: 0.5rem;
 }
 
 /* Timestamp Display */
@@ -206,7 +210,7 @@
 .replies {
   margin-left: calc(var(--_avatar-size, 0) / 2);
   border-left: 2px solid var(--_thread-line);
-  padding-left: calc(0.5rem - var(--_avatar-size, 0));
+  padding-left: calc(1rem - var(--_avatar-size, 0));
 }
 
 /* Load More Buttons

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -131,7 +131,6 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
   padding-bottom: 0.5rem;
 }
 

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -163,7 +163,7 @@
 /* Timestamp Display */
 .timestamp-link {
   color: var(--_muted-text);
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   text-decoration: none;
 }
 

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -45,6 +45,10 @@
   --_warning-button-hover: var(--bc-warning-button-hover,
     var(--bs-primary-dark, #0052a3));                                      /* Warning button hover */
 
+
+  /* Avatar */
+  --_avatar-size: var(--bc-avatar-size, 24px);
+
   /* Base Container Styles */
   font-family: system-ui, -apple-system, sans-serif;
   max-width: 800px;
@@ -107,25 +111,33 @@
  * User profile pictures and placeholders */
 .avatar,
 .avatar-placeholder {
-  width: 24px;
-  height: 24px;
+  width: var(--_avatar-size);
+  height: var(--_avatar-size);
   border-radius: 50%;
   background-color: var(--_bg-avatar);
+  left: calc(var(--_avatar-size, 0) / -2);
 }
 
 /* Comment Styles
  * Individual comment containers and their components */
 .comment {
-  margin: 1rem 0;
-  padding: 0.5rem;
+  margin: 0;
+  padding-inline: 0.5rem;
+  padding-top: 1rem;
   border-radius: 4px;
 }
 
 .comment-header {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  margin-bottom: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.comment-body, .comment-header {
+  margin-left: calc(var(--_avatar-size, 0) / 2);
+  border-left: 2px solid var(--_thread-line);
 }
 
 .comment-body > p:last-of-type {
@@ -138,6 +150,12 @@
   margin-top: 0.25rem;
   color: var(--_muted-text);
   font-size: 0.8em;
+}
+
+.comment-header,
+.comment-body,
+.replies {
+  padding-left: calc(0.5rem + var(--_avatar-size, 0) / 2);
 }
 
 /* Timestamp Display */
@@ -174,6 +192,11 @@
   color: var(--_text-color);
 }
 
+.avatar {
+  position: absolute;
+  left: calc(var(--_avatar-size, 0) / -2);
+}
+
 .author-link:hover {
   text-decoration: underline;
   color: var(--_link-hover-color);
@@ -186,8 +209,7 @@
 /* Reply Thread Styles
  * Visual hierarchy for comment threads */
 .replies {
-  margin-left: 1.5rem;
-  padding-left: 1rem;
+  margin-left: calc(var(--_avatar-size, 0) / 2);
   border-left: 2px solid var(--_thread-line);
 }
 

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -153,8 +153,7 @@
 }
 
 .comment-header,
-.comment-body,
-.replies {
+.comment-body {
   padding-left: calc(0.5rem + var(--_avatar-size, 0) / 2);
 }
 
@@ -202,15 +201,12 @@
   color: var(--_link-hover-color);
 }
 
-.handle {
-  color: var(--_muted-text);
-}
-
 /* Reply Thread Styles
  * Visual hierarchy for comment threads */
 .replies {
   margin-left: calc(var(--_avatar-size, 0) / 2);
   border-left: 2px solid var(--_thread-line);
+  padding-left: calc(0.5rem - var(--_avatar-size, 0));
 }
 
 /* Load More Buttons

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -128,11 +128,16 @@
   margin-bottom: 0.5rem;
 }
 
-.comment-actions {
+.comment-body > p:last-of-type {
+  margin-bottom: 0;
+}
+
+.comment-stats {
   display: flex;
   gap: 1rem;
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
   color: var(--_muted-text);
+  font-size: 0.8em;
 }
 
 /* Timestamp Display */

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -170,6 +170,7 @@ You may specify these variables in your document's CSS or in a custom CSS file u
 | `--bc-thread-line` | Reply thread lines | `var(--bs-border-color)` |
 | `--bc-warning-text` | Warning text | `var(--bs-danger)` |
 | `--bc-warning-button` | Warning button | `var(--bs-primary)` |
+| `--bc-avatar-size` | Avatar size | `24px` |
 
 ## Limitations
 


### PR DESCRIPTION
| Before | After |
|:--:|:--:|
| ![image](https://github.com/user-attachments/assets/9f2222ca-d009-4bf4-89d3-c567edeb54be) | ![image](https://github.com/user-attachments/assets/4d1bcd3f-220f-4c30-86c3-68eed0f1f070) |

## Notes

I refactored the stats bar code so that we re-use it for both the main stats bar and the posts stats, but we only use icon and show zero counts in the main stats bar. (I also updated pluralization while here.) This reduces visual clutter a bit, including with a small bump down in the stats bar text size for individual comments.

Then, we resolve #22 by using only the display name or the handle.

We also resolve #21 by using the avatar icon as an anchor, adding a border to the top level posts and using consistent spacing throughout. I also added a `--bc-avatar-size` custom property that can be used to adjust the size of the avatar and the layout is responsive.

Fixes #22
Fixes #21