### PR TITLE
refactor: `n-show-init` and `n-show-more` to replace `visible-comments` and `visible-subcomments`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ bluesky-comments:
   mute-users:
     - "did:plc:1234abcd"
   filter-empty-replies: true
-  visible-comments: 3
-  visible-subcomments: 3
+  n-show-init: 3
+  n-show-more: 2
 ---
 ```
 
@@ -77,8 +77,8 @@ bluesky-comments:
 - `mute-patterns`: An array of strings or regex patterns (enclosed in `/`) to filter out comments containing specific text
 - `mute-users`: An array of Bluesky DIDs to filter out comments from specific users
 - `filter-empty-replies`: Boolean flag to filter out empty or very short replies (default: `true`)
-- `visible-comments`: Number of top-level comments to show initially (default: `3`)
-- `visible-subcomments`: Number of replies to show initially under each comment (default: `3`)
+- `n-show-init`: Number of top-level comments to show initially (default: `3`)
+- `n-show-more`: Number of replies to reveal when the user clicks on the "Show more" button (default: `2`)
 
 Users can click "Show more" buttons to reveal additional comments and replies beyond these initial limits. Filtered comments are counted and displayed at the top of the comments section to maintain transparency about moderation.
 

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -44,6 +44,14 @@ class BlueskyComments extends HTMLElement {
           delete userConfig.visibleComments;
           delete userConfig.visibleSubComments;
         }
+        ['nShowInit', 'nShowMore'].forEach(prop => {
+          if (typeof userConfig[prop] !== "number") {
+            userConfig[prop] = parseInt(userConfig[prop])
+            if (isNaN(userConfig[prop])) {
+              delete userConfig[prop]
+            }
+          }
+        })
         this.config = { ...this.config, ...userConfig };
       } catch (err) {
         console.error('Error parsing config:', err);
@@ -210,7 +218,7 @@ class BlueskyComments extends HTMLElement {
 
     // Initialize or increment the visibility count for this comment
     const currentCount = this.replyVisibilityCounts.get(commentId) || this.config.nShowInit;
-    const newCount = currentCount + this.config.nShowInit;
+    const newCount = currentCount + this.config.nShowMore;
     this.replyVisibilityCounts.set(commentId, newCount);
 
     // Re-render the comment with updated visibility
@@ -303,7 +311,7 @@ class BlueskyComments extends HTMLElement {
           ${this.renderReplies(visibleReplies, depth + 1)}
           ${hiddenReplies.length > 0 ?
             `<button class="show-more-replies" data-comment-id="${commentId}">
-              Show ${hiddenReplies.length} more replies
+              Show ${this.config.nShowMore} more of ${hiddenReplies.length}  replies
               </button>` : ''}
         </div>
       </div>
@@ -390,7 +398,7 @@ class BlueskyComments extends HTMLElement {
       </div>
       ${remainingCount > 0 ?
         `<button class="show-more">
-          Show ${remainingCount} more comments
+          Show ${this.config.nShowMore} more of ${remainingCount} comments
           </button>` : ''}
     `;
 

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -36,12 +36,6 @@ class BlueskyComments extends HTMLElement {
     if (configStr) {
       try {
         const userConfig = JSON.parse(configStr);
-        // Handle legacy config properties
-        if (userConfig.visibleComments || userConfig.visibleSubComments) {
-          userConfig.nShowInit = userConfig.visibleComments || userConfig.visibleSubComments || 3;
-          delete userConfig.visibleComments;
-          delete userConfig.visibleSubComments;
-        }
         ['nShowInit', 'nShowMore'].forEach(prop => {
           if (typeof userConfig[prop] !== "number") {
             userConfig[prop] = parseInt(userConfig[prop])

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -49,6 +49,7 @@ class BlueskyComments extends HTMLElement {
       {attr: 'n-show-more', prop: 'nShowMore'}
     ].forEach(({attr, prop}) => {
       let value = this.getAttribute(attr);
+      if (!value) return;
       if (typeof value !== "number") {
         value = parseInt(value);
         if (!isNaN(value)) {

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -331,11 +331,16 @@ class BlueskyComments extends HTMLElement {
 
   renderShowMoreButton(postId, remainingCount) {
     if (remainingCount <= 0) return '';
+    const nReveal = Math.min(this.config.nShowMore, remainingCount);
+    const txtComment = remainingCount == 1 ? 'comment' : 'comments';
+
+    let txtButton = `Show ${nReveal} more of ${remainingCount} ${txtComment}`
+    if (remainingCount <= nReveal) {
+      txtButton = `Show ${remainingCount} more ${txtComment}`
+    }
 
     return `
-      <button class="show-more-replies" data-post-id="${postId}">
-        Show ${this.config.nShowMore} more of ${remainingCount} ${postId === 'root' ? 'comments' : 'replies'}
-      </button>
+      <button class="show-more-replies" data-post-id="${postId}">${txtButton}</button>
     `;
   }
 

--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -117,8 +117,12 @@ local function mergeKwargsWithMeta(kwargs, meta)
     if type(value) ~= "string" then
       error("Invalid value for '" .. key .. "'. Values must be strings.")
     end
-    if key == "mute-patterns" or key == "mute-users" then
+
+    if filter_config_attrs[key] then
       value = quarto.json.decode(value)
+    end
+
+    if key == "mute-patterns" or key == "mute-users" then
       if attrs[key] then
         -- merge with global metadata mute settings rather than overriding
         for i = 1, #value do

--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -131,7 +131,7 @@ local function mergeKwargsWithMeta(kwargs, meta)
       else
         attrs[key] = value
       end
-    else
+    elseif key ~= "uri" then
       attrs[key] = value
     end
   end
@@ -194,10 +194,6 @@ function shortcode(args, kwargs, meta)
     postUri = kwargsUri
   elseif #args == 1 then
     postUri = args[1]
-  end
-
-  if kwargsUri ~= '' then
-    kwargs.remove('uri')
   end
 
   if postUri == nil then

--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -36,8 +36,7 @@ local function getFilterConfig(config)
   end
 
   if config['visible-comments'] then
-    utils.log_warn("`visible-comments` was deprecated, please use `n-show-init` instead.")
-    filterConfig.visibleComments = tonumber(pandoc.utils.stringify(config['visible-comments']))
+    utils.log_warn("`visible-comments` is deprecated and no longer used, please use `n-show-init` instead.")
   end
 
   if config['visible-subcomments'] then

--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -10,7 +10,6 @@ local function getFilterConfig(config)
 
   quarto.log.output(config)
 
-  -- Extract filter configuration with defaults
   local filterConfig = {
     mutePatterns = {},
     muteUsers = {},
@@ -36,19 +35,19 @@ local function getFilterConfig(config)
     filterConfig.filterEmptyReplies = config['filter-empty-replies']
   end
 
-  if config['n-show-init'] then
-    filterConfig.nShowInit = tonumber(pandoc.utils.stringify(config['n-show-init']))
-  end
-
-  if config['visible-comments'] then
+  if not config['n-show-init'] and config['visible-comments'] then
     utils.log_warn("`visible-comments` was deprecated, please use `n-show-init` instead.")
-    filterConfig.visibleComments = tonumber(pandoc.utils.stringify(config['visible-comments']))
+    filterConfig.nShowInit = tonumber(pandoc.utils.stringify(config['visible-comments']))
   end
 
   if config['visible-subcomments'] then
-    utils.log_warn("`visible-subcomments` was deprecated, please use `n-show-init` instead.")
-    filterConfig.visibleSubComments = tonumber(pandoc.utils.stringify(config['visible-subcomments']))
+    utils.log_warn("`visible-subcomments` is deprecated and no longer used, please use `n-show-init` instead.")
   end
+
+  local numericKeys = {
+    nShowInit = true,
+    nShowMore = true
+  }
 
   -- Add any additional config values
   for key, value in pairs(config) do
@@ -56,7 +55,12 @@ local function getFilterConfig(config)
     local camelKey = key:gsub("%-(%w)", function(match) return match:upper() end)
     -- Only add if not already in filterConfig
     if filterConfig[camelKey] == nil then
-      filterConfig[camelKey] = pandoc.utils.stringify(value)
+      value = pandoc.utils.stringify(value)
+      if numericKeys[camelKey] then
+        value = tonumber(value)
+      end
+      ---@diagnostic disable-next-line: assign-type-mismatch
+      filterConfig[camelKey] = value
     end
   end
 

--- a/_extensions/bluesky-comments/utils.lua
+++ b/_extensions/bluesky-comments/utils.lua
@@ -17,6 +17,10 @@ function utils.log_info(msg)
   quarto.log.info(utils.bcMessage(msg))
 end
 
+function utils.log_warn(msg)
+  quarto.log.warning(utils.bcMessage(msg))
+end
+
 function utils.log_output(msg)
   quarto.log.output(utils.bcMessage(msg))
 end

--- a/_extensions/bluesky-comments/utils.lua
+++ b/_extensions/bluesky-comments/utils.lua
@@ -25,4 +25,17 @@ function utils.log_output(msg)
   quarto.log.output(utils.bcMessage(msg))
 end
 
+function utils.isKeyInTable(table, keyToFind)
+  for key, _ in pairs(table) do
+      if key == keyToFind then
+          return true
+      end
+  end
+  return false
+end
+
+function utils.toCamelCase(x)
+  return x:gsub("%-(%w)", function(match) return match:upper() end)
+end
+
 return utils

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -61,12 +61,12 @@ at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26
 **Shortcode:**
 
 ```markdown
-{{{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 >}}}
+{{{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 mute-patterns='["👍"]' >}}}
 ```
 
 **Live:**
 
-{{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 >}}
+{{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 mute-patterns='["👍"]' >}}
 
 ## Medium Thread
 

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -9,8 +9,8 @@ bluesky-comments:
     - "📌"
     - "🔥"
   filter-empty-replies: true
-  visible-comments: 3
-  visible-subcomments: 5
+  n-show-init: 3
+  n-show-more: 2
 ---
 
 This document shows an example of the Bluesky Comments extension in Quarto embedding comments from multiple Bluesky posts in a single document.
@@ -33,11 +33,17 @@ bluesky-comments:
     - "📌"
     - "🔥"
   filter-empty-replies: true
-  visible-comments: 3
-  visible-subcomments: 5
+  n-show-init: 3
+  n-show-more: 2
 ```
 
 We could also supply `mute-users` to mute specific users from the comments; however, we have not done so in this example.
+
+Note that each of these settings can also be added directly to the shortcode to be applied specifically to that comment section:
+
+```markdown
+{{{< bluesky-comments at://did:plc:fgeozid7uyx2lfz3yo7zvm3b/app.bsky.feed.post/3lbtwdydxrk26 mute-patterns='["📌", "🔥"]' filter-empty-replies="true" >}}}
+```
 
 # Multiple Comment Sections
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -106,8 +106,8 @@ bluesky-comments:
   mute-users:
     - "did:plc:1234abcd"
   filter-empty-replies: true
-  visible-comments: 3
-  visible-subcomments: 3
+  n-show-init: 3
+  n-show-more: 2
 ---
 ```
 
@@ -117,8 +117,8 @@ bluesky-comments:
 - `mute-patterns`: An array of strings or regex patterns (enclosed in `/`) to filter out comments containing specific text
 - `mute-users`: An array of Bluesky DIDs to filter out comments from specific users
 - `filter-empty-replies`: Boolean flag to filter out empty or very short replies (default: `true`)
-- `visible-comments`: Number of top-level comments to show initially (default: `3`)
-- `visible-subcomments`: Number of replies to show initially under each comment (default: `3`)
+- `n-show-init`: Number of top-level comments to show initially (default: `3`)
+- `n-show-more`: Number of replies to reveal when the user clicks on the "Show more" button (default: `2`)
 
 Users can click "Show more" buttons to reveal additional comments and replies beyond these initial limits. Filtered comments are counted and displayed at the top of the comments section to maintain transparency about moderation.
 

--- a/docs/tests/test-n-show-init.qmd
+++ b/docs/tests/test-n-show-init.qmd
@@ -1,0 +1,26 @@
+---
+title: "Initial shown and revealed"
+description: |
+  Test initially shown posts and number of posts revealed with "show more".
+
+bluesky-comments:
+  profile: did:plc:72jpccg3u3vbohc67rqrplei
+
+other-thing: true
+---
+
+## `n-show-init="2" n-show-more="1"`
+
+```markdown
+{{{< bluesky-comments at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lbu5opiixc2j n-show-init="2" n-show-more=1 >}}}
+```
+
+{{< bluesky-comments at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lbu5opiixc2j n-show-init=2 n-show-more=1 >}}
+
+## `n-show-init="4" n-show-more=2`
+
+```markdown
+{{{< bluesky-comments at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lbu5opiixc2j n-show-init="4" n-show-more=2 >}}}
+```
+
+{{< bluesky-comments at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lbu5opiixc2j n-show-init="4" n-show-more=2 >}}

--- a/docs/tests/test-n-show-init.qmd
+++ b/docs/tests/test-n-show-init.qmd
@@ -4,10 +4,26 @@ description: |
   Test initially shown posts and number of posts revealed with "show more".
 
 bluesky-comments:
-  profile: did:plc:72jpccg3u3vbohc67rqrplei
+  n-show-init: 1
+  n-show-more: 2
 
 other-thing: true
 ---
+
+## Default, uses YAML front matter
+
+```markdown
+---
+bluesky-comments:
+  n-show-init: 1
+  n-show-more: 2
+---
+
+{{{< bluesky-comments at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lbu5opiixc2j>}}}
+```
+
+{{< bluesky-comments at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lbu5opiixc2j >}}
+
 
 ## `n-show-init="2" n-show-more="1"`
 

--- a/docs/tests/test-post-url.qmd
+++ b/docs/tests/test-post-url.qmd
@@ -50,3 +50,11 @@ bluesky-comments:
 ```
 
 {{< bluesky-comments uri="3lbu5opiixc2j" >}}
+
+### With `profile` as a shortcode kwarg
+
+```markdown
+{{{< bluesky-comments 3lbtwdydxrk26 profile="did:plc:fgeozid7uyx2lfz3yo7zvm3b" >}}}
+```
+
+{{< bluesky-comments 3lbtwdydxrk26 profile="did:plc:fgeozid7uyx2lfz3yo7zvm3b" >}}


### PR DESCRIPTION
Leading up to #15, this refactors the component to use `n-show-init` as the number of posts initially shown at a given level and `n-show-more` as the number of posts revealed when clicking on a "show more posts" button.

This refactor simplifies the component a bit in that we don't maintain separate logic for top-level comments and their replies, the visibility of replies at any given node is now controlled via the same code paths.

I'm open to workshopping the config parameter names. I like the `n-show-*` prefix because it groups "show" arguments while clearly communicated we're expecting a number. I'm also planning to add `n-show-depth` or `n-show-init-depth` to control how far down into a comment tree we render initially.