### PR TITLE
feat: Reduce scope of content labelling and improve UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ For more targeted styling, override the component's custom properties either in 
   --bc-link-color: #0070f3;     /* Links */
   --bc-border-color: #eaeaea;   /* Borders */
   --bc-thread-line: #e1e1e1;    /* Reply thread lines */
-  --bc-warning-text: #ff4444;   /* Warning messages */
 }
 ```
 
@@ -124,13 +123,16 @@ You may specify these variables in your document's CSS or in a custom CSS file u
 | `--bc-link-color` | Link color | `var(--bs-link-color)` |
 | `--bc-link-hover-color` | Link hover color | `var(--bs-link-hover-color)` |
 | `--bc-notice-bg` | Notice background | `var(--bs-light)` |
-| `--bc-warning-bg` | Warning background | `var(--bs-light)` |
 | `--bc-avatar-bg` | Avatar placeholder | `var(--bs-secondary-bg)` |
+| `--bc-avatar-size` | Avatar size | `24px` |
 | `--bc-border-color` | General borders | `var(--bs-border-color)` |
 | `--bc-thread-line` | Reply thread lines | `var(--bs-border-color)` |
-| `--bc-warning-text` | Warning text | `var(--bs-danger)` |
+| `--bc-thread-line-width` | Reply thread line width | `2px` |
+| `--bc-warning-text` | Content warning text | `var(--bc-muted-fg)` |
+| `--bc-warning-bg` | Warning background | `var(--bc-muted-bg)` |
 | `--bc-warning-button` | Warning button | `var(--bs-primary)` |
-| `--bc-avatar-size` | Avatar size | `24px` |
+| `--bc-muted-bg` | Muted background | `--bs-emphasis-color-rgb` at 0.5% alpha |
+| `--bc-muted-fg` | Muted foreground | `--bs-emphasis-color-rgb` at 65% alpha |
 
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ You may specify these variables in your document's CSS or in a custom CSS file u
 | `--bc-avatar-bg` | Avatar placeholder | `var(--bs-secondary-bg)` |
 | `--bc-avatar-size` | Avatar size | `24px` |
 | `--bc-border-color` | General borders | `var(--bs-border-color)` |
+| `--bc-border-radius` | General border radius | `var(--bs-border-radius)` |
 | `--bc-thread-line` | Reply thread lines | `var(--bs-border-color)` |
 | `--bc-thread-line-width` | Reply thread line width | `2px` |
 | `--bc-warning-text` | Content warning text | `var(--bc-muted-fg)` |

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For more targeted styling, override the component's custom properties either in 
   --bc-muted-text: #666;        /* Secondary text */
   --bc-link-color: #0070f3;     /* Links */
   --bc-border-color: #eaeaea;   /* Borders */
-  --bc-thread-line: #e1e1e1;    /* Reply thread lines */
+  --bc-thread-line: #e1e1e1;    /* Reply thread line color */
 }
 ```
 

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -444,6 +444,7 @@ class BlueskyComments extends HTMLElement {
 
     const labelDisplay = {
       sexual: 'adult content',
+      porn: 'pornographic adult content',
     };
 
     // TODO: Filter out negated labels, see https://atproto.blue/en/latest/atproto/atproto_client.models.com.atproto.label.defs.html

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -15,7 +15,6 @@ class BlueskyComments extends HTMLElement {
     this.nShowInit = 3;
     this.nShowMore = 2;
     this.postVisibilityCounts = new Map();
-    this.acknowledgedWarnings = new Set();
 
     // Bind methods
     this.showMoreReplies = this.showMoreReplies.bind(this);

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -445,6 +445,8 @@ class BlueskyComments extends HTMLElement {
     const labelDisplay = {
       sexual: 'adult content',
       porn: 'pornographic adult content',
+      '!warn': 'content warning',
+      '!hide': 'content warning',
     };
 
     // TODO: Filter out negated labels, see https://atproto.blue/en/latest/atproto/atproto_client.models.com.atproto.label.defs.html

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -441,7 +441,7 @@ class BlueskyComments extends HTMLElement {
     return `
     <div class="content-warning">
       <span class="warning-label">${formattedLabels}</span>
-      <button class="warning-button btn btn-outline-secondary btn-sm ms-auto">Show content</button>
+      <button class="warning-button btn btn-sm btn-soft ms-auto">Show content</button>
     </div>`;
   }
 

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -396,6 +396,11 @@ class BlueskyComments extends HTMLElement {
     const contentHtml = `
       <h2>Comments</h2>
       <div class="stats">${this.#renderStatsBar(this.thread.post)}</div>
+      <p class="reply-prompt">
+        <a href="${this.postUrl}"
+          target="_blank"
+        >Reply on Bluesky</a> to join the conversation.
+      </p>
       ${
         filteredCount > 0
           ? `<p class="filtered-notice">
@@ -405,11 +410,6 @@ class BlueskyComments extends HTMLElement {
           </p>`
           : ''
       }
-      <p class="reply-prompt">
-        <a href="${
-          this.postUrl
-        }" target="_blank">Reply on Bluesky</a> to join the conversation.
-      </p>
       <div class="comments-list">
         ${visibleReplies.map(reply => this.renderComment(reply, 0)).join('')}
       </div>

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -455,6 +455,10 @@ class BlueskyComments extends HTMLElement {
       .map(l => labelDisplay[l.val] || l.val)
       .map(l => l.replaceAll('-', ' '))
       .sort()
+      .reduce((acc, l) => {
+        if (acc.includes(l)) return acc;
+        return [...acc, l];
+      }, [])
       .join(', ');
 
     formattedLabels =

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -30,7 +30,7 @@
   /* Background Colors
    * Define background colors for various component elements */
   --_bg-notice: var(--bc-notice-bg, var(--bs-light, #f8f9fa));             /* Notice background */
-  --_bg-warning: var(--bc-warning-bg, var(--bs-light, #f8f9fa));           /* Warning background */
+  --_bg-warning: var(--bc-warning-bg, rgba(var(--bs-emphasis-color-rgb, 0, 0, 0), 0.05)); /* Warning background */
   --_bg-avatar: var(--bc-avatar-bg, var(--bs-secondary-bg, #eee));         /* Avatar placeholder */
 
   /* Border Colors
@@ -41,10 +41,7 @@
 
   /* Warning Colors
    * Styles for warning messages and buttons */
-  --_warning-text: var(--bc-warning-text, var(--bs-danger, #dc3545));      /* Warning text */
-  --_warning-button: var(--bc-warning-button, var(--bs-primary, #0066cc)); /* Warning button */
-  --_warning-button-hover: var(--bc-warning-button-hover,
-    var(--bs-primary-dark, #0052a3));                                      /* Warning button hover */
+  --_warning-text: var(--bc-warning-text, var(var(--bs-secondary-text-emphasis), #dc3545));      /* Warning text */
 
 
   /* Avatar */
@@ -124,7 +121,6 @@
   margin: 0;
   padding: 0;
   padding-right: 0.5rem;
-  border-radius: 4px;
   border-left: var(--_thread-line-width, 2px) solid var(--_thread-line);
   margin-bottom: 1rem;
   position: relative;
@@ -153,10 +149,6 @@
 .comment-body,
 .content-warning {
   padding-left: calc(0.5rem + var(--_avatar-size, 0) / 2);
-}
-
-.replies > .comment {
-  padding-left: 0.5rem;
 }
 
 /* Timestamp Display */
@@ -206,9 +198,8 @@
 /* Reply Thread Styles
  * Visual hierarchy for comment threads */
 .replies {
-  margin-left: calc(var(--_avatar-size, 0) / 2);
-  border-left: 2px solid var(--_thread-line);
-  padding-left: calc(1rem - var(--_avatar-size, 0));
+  margin-top: 1rem;
+  margin-left: calc(var(--_avatar-size));
 }
 
 /* Load More Buttons
@@ -259,15 +250,41 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.5rem;
-  margin-left: var(--_avatar-size, 1rem);
+  margin-left: calc(0.5rem + var(--_avatar-size, 0) / 2);
+  margin-bottom: 0.25rem;
+  padding: 0.25rem 0.5rem;
   background: var(--_bg-warning);
   border: 1px solid var(--_border-color);
-  border-radius: 4px;
-  font-size: 0.9rem;
+  border-radius: var(--bs-border-radius);
+  font-size: 0.8rem;
 }
 
 .warning-label {
   color: var(--_warning-text);
   font-weight: 500;
+}
+
+.warning-button {
+  padding: 0.25rem 0.5rem;
+  color: var(--_warning-text);
+}
+
+.btn-soft {
+  --_btn-bg-opacity: 0;
+  --_btn-bg-rgb: var(--bs-emphasis-color-rgb);
+  --_btn-bg-color: rgba(var(--_btn-bg-rgb), var(--_btn-bg-opacity));
+  background-color: var(--_btn-bg-color);
+  color: var(--bs-emphasis-color);
+  border-color: transparent;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.btn-soft:hover {
+  --_btn-bg-opacity: 0.1;
+  background-color: var(--_btn-bg-color);
+}
+
+.btn-soft:focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.25rem rgba(var(--_btn-bg-rgb), 0.5);
 }

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -257,57 +257,18 @@
 /* Content Warning System
  * Styles for content warning labels and interactions */
 .content-warning {
-  margin: 1rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem;
+  margin-left: var(--_avatar-size, 1rem);
   background: var(--_bg-warning);
   border: 1px solid var(--_border-color);
   border-radius: 4px;
-  padding: 1.5rem;
-}
-
-.warning-content {
-  max-width: 600px;
-  margin: 0 auto;
-}
-
-.label-warning {
-  margin-bottom: 1rem;
-}
-
-.label-warning strong {
-  display: block;
-  font-size: 1.1rem;
-  margin-bottom: 0.5rem;
-  color: var(--_warning-text);
-}
-
-.label-attribution {
   font-size: 0.9rem;
-  color: var(--_muted-text);
-  margin-top: 0.5rem;
 }
 
-.warning-prompt {
+.warning-label {
+  color: var(--_warning-text);
   font-weight: 500;
-  margin: 1.5rem 0;
-}
-
-.warning-divider {
-  border: 0;
-  border-top: 1px solid var(--_border-color);
-  margin: 1rem 0;
-}
-
-.warning-button {
-  background: var(--_warning-button);
-  color: white;
-  border: none;
-  padding: 0.75rem 1.5rem;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 1rem;
-  transition: background-color 0.2s;
-}
-
-.warning-button:hover {
-  background: var(--_warning-button-hover);
 }

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -29,8 +29,8 @@
 
   /* Background Colors
    * Define background colors for various component elements */
-  --_bg-notice: var(--bc-notice-bg, var(--bs-light, #f8f9fa));             /* Notice background */
-  --_bg-warning: var(--bc-warning-bg, rgba(var(--bs-emphasis-color-rgb, 0, 0, 0), 0.05)); /* Warning background */
+  --_bg-soft: rgba(var(--bs-emphasis-color-rgb, 0, 0, 0), 0.05);
+  --_bg-notice: var(--bc-notice-bg, var(--_bg-soft));             /* Notice background */
   --_bg-avatar: var(--bc-avatar-bg, var(--bs-secondary-bg, #eee));         /* Avatar placeholder */
 
   /* Border Colors
@@ -40,8 +40,9 @@
   --_thread-line-width: var(--bc-thread-line-width, 2px);
 
   /* Warning Colors
-   * Styles for warning messages and buttons */
-  --_warning-text: var(--bc-warning-text, var(var(--bs-secondary-text-emphasis), #dc3545));      /* Warning text */
+   * Styles for content warning */
+  --_warning-text: var(--bc-warning-text, var(--bs-secondary-text-emphasis, #2b2f32));      /* Warning text */
+  --_warning-bg: var(--bc-warning-bg, var(--_bg-soft)); /* Warning background */
 
 
   /* Avatar */
@@ -253,7 +254,7 @@
   margin-left: calc(0.5rem + var(--_avatar-size, 0) / 2);
   margin-bottom: 0.25rem;
   padding: 0.25rem 0.5rem;
-  background: var(--_bg-warning);
+  background: var(--_warning-bg);
   border: 1px solid var(--_border-color);
   border-radius: var(--bs-border-radius);
   font-size: 0.8rem;

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -37,6 +37,7 @@
    * Control the appearance of borders and dividers */
   --_border-color: var(--bc-border-color, var(--bs-border-color, #e9ecef)); /* General borders */
   --_thread-line: var(--bc-thread-line, var(--bs-border-color, #eee));      /* Comment thread lines */
+  --_thread-line-width: var(--bc-thread-line-width, 2px);
 
   /* Warning Colors
    * Styles for warning messages and buttons */
@@ -115,16 +116,18 @@
   height: var(--_avatar-size);
   border-radius: 50%;
   background-color: var(--_bg-avatar);
-  left: calc(var(--_avatar-size, 0) / -2);
 }
 
 /* Comment Styles
  * Individual comment containers and their components */
 .comment {
   margin: 0;
+  padding: 0;
   padding-right: 0.5rem;
-  padding-top: 1rem;
   border-radius: 4px;
+  border-left: var(--_thread-line-width, 2px) solid var(--_thread-line);
+  margin-bottom: 1rem;
+  position: relative;
 }
 
 .comment-header {
@@ -132,11 +135,6 @@
   display: flex;
   flex-direction: column;
   padding-bottom: 0.5rem;
-}
-
-.comment-body, .comment-header {
-  margin-left: calc(var(--_avatar-size, 0) / 2);
-  border-left: 2px solid var(--_thread-line);
 }
 
 .comment-body > p:last-of-type {
@@ -152,7 +150,8 @@
 }
 
 .comment-header,
-.comment-body {
+.comment-body,
+.content-warning {
   padding-left: calc(0.5rem + var(--_avatar-size, 0) / 2);
 }
 
@@ -196,7 +195,7 @@
 
 .avatar {
   position: absolute;
-  left: calc(var(--_avatar-size, 0) / -2);
+  left: calc((var(--_avatar-size, 0) + var(--_thread-line-width, 2px)) / -2);
 }
 
 .author-link:hover {

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -21,17 +21,19 @@
 
   /* Text Colors
    * Control the appearance of various text elements */
-  --_text-color: var(--bc-text-color, var(--bs-body-color, #000));         /* Main text color */
-  --_muted-text: var(--bc-muted-text, var(--bs-secondary-color, #666));    /* Secondary text color */
-  --_link-color: var(--bc-link-color, var(--bs-link-color, #0066cc));      /* Link color */
+  --_text-color: var(--bc-text-color, var(--bs-body-color, #000));       /* Main text color */
+  --_muted-text: var(--bc-muted-text, var(--bs-secondary-color, #666));  /* Secondary text color */
+  --_link-color: var(--bc-link-color, var(--bs-link-color, #0066cc));    /* Link color */
   --_link-hover-color: var(--bc-link-hover-color,
-    var(--bs-link-hover-color, #0052a3));                                  /* Link hover color */
+    var(--bs-link-hover-color, #0052a3));                                /* Link hover color */
+
+  --_muted-bg: var(--bc-muted-bg, rgba(var(--bs-emphasis-color-rgb, 0, 0, 0), 0.05));
+  --_muted-fg: var(--bc-muted-fg, rgba(var(--bs-emphasis-color-rgb, 0, 0, 0), 0.65));
 
   /* Background Colors
    * Define background colors for various component elements */
-  --_bg-soft: rgba(var(--bs-emphasis-color-rgb, 0, 0, 0), 0.05);
-  --_bg-notice: var(--bc-notice-bg, var(--_bg-soft));             /* Notice background */
-  --_bg-avatar: var(--bc-avatar-bg, var(--bs-secondary-bg, #eee));         /* Avatar placeholder */
+  --_bg-notice: var(--bc-notice-bg, var(--_muted-bg));               /* Notice background */
+  --_bg-avatar: var(--bc-avatar-bg, var(--bs-secondary-bg, #eee)); /* Avatar placeholder */
 
   /* Border Colors
    * Control the appearance of borders and dividers */
@@ -41,9 +43,8 @@
 
   /* Warning Colors
    * Styles for content warning */
-  --_warning-text: var(--bc-warning-text, var(--bs-secondary-text-emphasis, #2b2f32));      /* Warning text */
-  --_warning-bg: var(--bc-warning-bg, var(--_bg-soft)); /* Warning background */
-
+  --_warning-text: var(--bc-warning-text, var(--_muted-fg)); /* Warning text */
+  --_warning-bg: var(--bc-warning-bg, var(--_muted-bg));     /* Warning background */
 
   /* Avatar */
   --_avatar-size: var(--bc-avatar-size, 24px);
@@ -142,7 +143,7 @@
   display: flex;
   gap: 1rem;
   margin-top: 0.25rem;
-  color: var(--_muted-text);
+  color: var(--_muted-fg);
   font-size: 0.8em;
 }
 
@@ -154,7 +155,7 @@
 
 /* Timestamp Display */
 .timestamp-link {
-  color: var(--_muted-text);
+  color: var(--_muted-fg);
   font-size: 0.8rem;
   text-decoration: none;
 }
@@ -172,7 +173,7 @@
   border-radius: 4px;
   padding: 0.75rem;
   margin: 1rem 0;
-  color: var(--_muted-text);
+  color: var(--_muted-fg);
   font-size: 0.9rem;
 }
 
@@ -275,7 +276,7 @@
   --_btn-bg-rgb: var(--bs-emphasis-color-rgb);
   --_btn-bg-color: rgba(var(--_btn-bg-rgb), var(--_btn-bg-opacity));
   background-color: var(--_btn-bg-color);
-  color: var(--bs-emphasis-color);
+  color: var(--_muted-fg);
   border-color: transparent;
   transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }

--- a/_extensions/bluesky-comments/styles.css
+++ b/_extensions/bluesky-comments/styles.css
@@ -49,6 +49,8 @@
   /* Avatar */
   --_avatar-size: var(--bc-avatar-size, 24px);
 
+  --_border-radius: var(--bc-border-radius, var(--bs-border-radius, 4px));
+
   /* Base Container Styles */
   font-family: system-ui, -apple-system, sans-serif;
   max-width: 800px;
@@ -170,7 +172,7 @@
 .filtered-notice {
   background-color: var(--_bg-notice);
   border: 1px solid var(--_border-color);
-  border-radius: 4px;
+  border-radius: var(--_border-radius);
   padding: 0.75rem;
   margin: 1rem 0;
   color: var(--_muted-fg);
@@ -257,7 +259,7 @@
   padding: 0.25rem 0.5rem;
   background: var(--_warning-bg);
   border: 1px solid var(--_border-color);
-  border-radius: var(--bs-border-radius);
+  border-radius: var(--_border-radius);
   font-size: 0.8rem;
 }
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -149,7 +149,6 @@ For more targeted styling, override the component's custom properties either in 
   --bc-link-color: #0070f3;     /* Links */
   --bc-border-color: #eaeaea;   /* Borders */
   --bc-thread-line: #e1e1e1;    /* Reply thread lines */
-  --bc-warning-text: #ff4444;   /* Warning messages */
 }
 ```
 
@@ -164,13 +163,17 @@ You may specify these variables in your document's CSS or in a custom CSS file u
 | `--bc-link-color` | Link color | `var(--bs-link-color)` |
 | `--bc-link-hover-color` | Link hover color | `var(--bs-link-hover-color)` |
 | `--bc-notice-bg` | Notice background | `var(--bs-light)` |
-| `--bc-warning-bg` | Warning background | `var(--bs-light)` |
 | `--bc-avatar-bg` | Avatar placeholder | `var(--bs-secondary-bg)` |
+| `--bc-avatar-size` | Avatar size | `24px` |
 | `--bc-border-color` | General borders | `var(--bs-border-color)` |
 | `--bc-thread-line` | Reply thread lines | `var(--bs-border-color)` |
-| `--bc-warning-text` | Warning text | `var(--bs-danger)` |
+| `--bc-thread-line-width` | Reply thread line width | `2px` |
+| `--bc-warning-text` | Content warning text | `var(--bc-muted-fg)` |
+| `--bc-warning-bg` | Warning background | `var(--bc-muted-bg)` |
 | `--bc-warning-button` | Warning button | `var(--bs-primary)` |
-| `--bc-avatar-size` | Avatar size | `24px` |
+| `--bc-muted-bg` | Muted background | `--bs-emphasis-color-rgb` at 0.5% alpha |
+| `--bc-muted-fg` | Muted foreground | `--bs-emphasis-color-rgb` at 65% alpha |
+
 
 ## Limitations
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -148,7 +148,7 @@ For more targeted styling, override the component's custom properties either in 
   --bc-muted-text: #666;        /* Secondary text */
   --bc-link-color: #0070f3;     /* Links */
   --bc-border-color: #eaeaea;   /* Borders */
-  --bc-thread-line: #e1e1e1;    /* Reply thread lines */
+  --bc-thread-line: #e1e1e1;    /* Reply thread line color */
 }
 ```
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -166,6 +166,7 @@ You may specify these variables in your document's CSS or in a custom CSS file u
 | `--bc-avatar-bg` | Avatar placeholder | `var(--bs-secondary-bg)` |
 | `--bc-avatar-size` | Avatar size | `24px` |
 | `--bc-border-color` | General borders | `var(--bs-border-color)` |
+| `--bc-border-radius` | General border radius | `var(--bs-border-radius)` |
 | `--bc-thread-line` | Reply thread lines | `var(--bs-border-color)` |
 | `--bc-thread-line-width` | Reply thread line width | `2px` |
 | `--bc-warning-text` | Content warning text | `var(--bc-muted-fg)` |

--- a/docs/tests/test-no-comments.qmd
+++ b/docs/tests/test-no-comments.qmd
@@ -1,0 +1,8 @@
+---
+title: No comments
+description: A thread without comments
+---
+
+Source: <https://bsky.app/profile/grrrck.xyz/post/3lcyp4he3nk2h>.
+
+{{< bluesky-comments at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lcyp4he3nk2h >}}


### PR DESCRIPTION
Fixes #11 

This PR makes content hiding for content labels work a bit more like it does on Bluesky. Content labels now hide the comment body, only show the content label, and only toggle the visibility of the comment body, rather than replacing the entire comment. It also no longer requires tracking acknowledged content warnings.

Along the way, I also realized we don't need to put the content warning on the main component, only individual comments, since the top-level post isn't actually shown (just its replies are).

## Before

![image](https://github.com/user-attachments/assets/73c8ed92-1b4a-46a2-a17c-472e1c0da257)

## After

### Hidden

![image](https://github.com/user-attachments/assets/811b7e52-8e73-4221-9829-f478590afdec)

### Expanded

![image](https://github.com/user-attachments/assets/70346be4-d34f-4234-a6b0-f54c57e10ec0)
