### PR TITLE
feat: Support `header` meta/inline attribute, default to no header

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ bluesky-comments:
 - `filter-empty-replies`: Boolean flag to filter out empty or very short replies, including bookmarking (📌) replies (default: `true`)
 - `n-show-init`: Number of top-level comments to show initially (default: `3`)
 - `n-show-more`: Number of replies to reveal when the user clicks on the "Show more" button (default: `2`)
+- `header`: Whether or not to add a level-2 header above the comments. Use `header="true"` as a shortcut for `header="Comments"` (default: `false`).
 
 Users can click "Show more" buttons to reveal additional comments and replies beyond these initial limits.
 

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -14,6 +14,7 @@ class BlueskyComments extends HTMLElement {
     this.profile = null;
     this.nShowInit = 3;
     this.nShowMore = 2;
+    this.header = false;
     this.postVisibilityCounts = new Map();
     this.hiddenReplies = []; // Replies moderated via Bluesky
 
@@ -60,6 +61,10 @@ class BlueskyComments extends HTMLElement {
     });
 
     this.profile = this.getAttribute('profile');
+
+    this.header = this.hasAttribute('header')
+      ? this.getAttribute('header')
+      : false;
 
     this.#setPostUri(this.getAttribute('post'));
 
@@ -472,8 +477,17 @@ class BlueskyComments extends HTMLElement {
     const remainingCount = filteredReplies.length - visibleCount;
     const filteredCount = this.countFilteredComments(this.thread.replies);
 
+    let headerHtml = '';
+    if (this.header !== false) {
+      if (['true', ''].includes(this.header)) {
+        headerHtml = '<h2>Comments</h2>';
+      } else {
+        headerHtml = `<h2>${this.header}</h2>`;
+      }
+    }
+
     const contentHtml = `
-      <h2>Comments</h2>
+      ${headerHtml}
       <div class="stats">${this.#renderStatsBar(this.thread.post, {
         adjustReplies: -1 * filteredCount,
       })}</div>

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -62,9 +62,9 @@ class BlueskyComments extends HTMLElement {
 
     this.profile = this.getAttribute('profile');
 
-    this.header = this.hasAttribute('header')
-      ? this.getAttribute('header')
-      : false;
+    if (this.hasAttribute('header')) {
+      this.header = this.getAttribute('header');
+    }
 
     this.#setPostUri(this.getAttribute('post'));
 

--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -198,7 +198,7 @@ function shortcode(args, kwargs, meta)
 
   if postUri == nil then
     errorMsg = errorMsg or
-        "Shortcode requires the Bluesky post URL, AT-proto URI, or post record key as an unnamed argument."
+    "Shortcode requires the Bluesky post URL, AT-proto URI, or post record key as an unnamed argument."
     utils.abort(errorMsg)
     return ""
   end

--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -198,7 +198,7 @@ function shortcode(args, kwargs, meta)
 
   if postUri == nil then
     errorMsg = errorMsg or
-    "Shortcode requires the Bluesky post URL, AT-proto URI, or post record key as an unnamed argument."
+        "Shortcode requires the Bluesky post URL, AT-proto URI, or post record key as an unnamed argument."
     utils.abort(errorMsg)
     return ""
   end
@@ -218,7 +218,9 @@ function shortcode(args, kwargs, meta)
     postUri = atUri
   end
 
+  quarto.log.output(kwargsWithMeta)
   local attrs = attrsFromKwargsMeta(kwargsWithMeta)
+  quarto.log.output("attrs: " .. attrs)
 
   -- Return the HTML div element with config
   return pandoc.RawBlock('html', string.format([[

--- a/_extensions/bluesky-comments/bluesky-comments.lua
+++ b/_extensions/bluesky-comments/bluesky-comments.lua
@@ -218,9 +218,7 @@ function shortcode(args, kwargs, meta)
     postUri = atUri
   end
 
-  quarto.log.output(kwargsWithMeta)
   local attrs = attrsFromKwargsMeta(kwargsWithMeta)
-  quarto.log.output("attrs: " .. attrs)
 
   -- Return the HTML div element with config
   return pandoc.RawBlock('html', string.format([[

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -119,6 +119,7 @@ bluesky-comments:
 - `filter-empty-replies`: Boolean flag to filter out empty or very short replies, including bookmarking (📌) replies (default: `true`)
 - `n-show-init`: Number of top-level comments to show initially (default: `3`)
 - `n-show-more`: Number of replies to reveal when the user clicks on the "Show more" button (default: `2`)
+- `header`: Whether or not to add a level-2 header above the comments. Use `header="true"` as a shortcut for `header="Comments"` (default: `false`).
 
 Users can click "Show more" buttons to reveal additional comments and replies beyond these initial limits.
 

--- a/docs/tests/test-facet-links.qmd
+++ b/docs/tests/test-facet-links.qmd
@@ -6,6 +6,9 @@ bluesky-comments:
   n-show-init: 2
 ---
 
+Also tests `header="true"`.
+
 Source: <https://bsky.app/profile/grrrck.xyz/post/3lg6fjlw2n225>.
 
-{{< bluesky-comments at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lg6fjlw2n225 >}}
+
+{{< bluesky-comments at://did:plc:72jpccg3u3vbohc67rqrplei/app.bsky.feed.post/3lg6fjlw2n225 header="true" >}}


### PR DESCRIPTION
Fixes #33

Removes the default level-2 "Comments" header and makes it configurable via `bluesky-comments.header` in the front matter or an inline `hedaer` argument:

- `header`: Whether or not to add a level-2 header above the comments. Use `header="true"` as a shortcut for `header="Comments"` (default: `false`).

