### PR TITLE
feat: Add `n-show-depth`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,15 @@ For example:
 
 ## Configuration
 
+### How to configure Bluesky comments
+
 The extension can be configured through your document's YAML frontmatter or the `_quarto.yml` configuration file. Add configuration options under the `bluesky-comments` key:
 
 ```yaml
 ---
 title: "My Document"
 bluesky-comments:
+  profile: did:plc:fgeozid7uyx2lfz3yo7zvm3b  # coatless.bsky.social
   mute-patterns:
     - "📌"
     - "🔥"
@@ -69,19 +72,34 @@ bluesky-comments:
   filter-empty-replies: true
   n-show-init: 3
   n-show-more: 2
+  n-show-depth: 3
 ---
 ```
 
+Each of these options can also be set directly for a single comments section by providing the option as an inline attribute in the shortcode, e.g. `{{{< bluesky-comments n-show-init=3 >}}}`. These values take precedence over the above settings.
+
 ### Available Options
 
-- `mute-patterns`: An array of strings or regex patterns (enclosed in `/`) to filter out comments containing specific text
-- `mute-users`: An array of Bluesky DIDs to filter out comments from specific users
-- `filter-empty-replies`: Boolean flag to filter out empty or very short replies, including bookmarking (📌) replies (default: `true`)
-- `n-show-init`: Number of top-level comments to show initially (default: `3`)
-- `n-show-more`: Number of replies to reveal when the user clicks on the "Show more" button (default: `2`)
-- `header`: Whether or not to add a level-2 header above the comments. Use `header="true"` as a shortcut for `header="Comments"` (default: `false`).
+`mute-patterns`
+:    An array of strings or regex patterns (enclosed in `/`) to filter out comments containing specific text.
 
-Users can click "Show more" buttons to reveal additional comments and replies beyond these initial limits.
+`mute-users`
+:    An array of Bluesky DIDs to filter out comments from specific users.
+
+`filter-empty-replies`
+:    Boolean flag to filter out empty or very short replies, including bookmarking (📌) replies (default: `true`).
+
+`n-show-init`
+:    Number of top-level comments to show initially (default: `3`).
+
+`n-show-more`
+:    Number of replies to reveal when the user clicks on the "Show more" button (default: `2`).
+
+`n-show-depth`
+:    Maximum depth of replies to show initially. Additional nested replies are revealed when the user clicks on the "Show nested replies" button.
+
+`header`
+:    Whether or not to add a level-2 header above the comments. Use `header="true"` as a shortcut for `header="Comments"` (default: `false`).
 
 ## Moderation
 

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -14,12 +14,15 @@ class BlueskyComments extends HTMLElement {
     this.profile = null;
     this.nShowInit = 3;
     this.nShowMore = 2;
+    this.nShowDepth = 3;
     this.header = false;
     this.postVisibilityCounts = new Map();
+    this.postVisibilityDepths = new Set();
     this.hiddenReplies = []; // Replies moderated via Bluesky
 
     // Bind methods
     this.showMoreReplies = this.showMoreReplies.bind(this);
+    this.showMoreDepth = this.showMoreDepth.bind(this);
   }
 
   get postUrl() {
@@ -49,6 +52,7 @@ class BlueskyComments extends HTMLElement {
     [
       { attr: 'n-show-init', prop: 'nShowInit' },
       { attr: 'n-show-more', prop: 'nShowMore' },
+      { attr: 'n-show-depth', prop: 'nShowDepth' },
     ].forEach(({ attr, prop }) => {
       let value = this.getAttribute(attr);
       if (!value) return;
@@ -277,6 +281,19 @@ class BlueskyComments extends HTMLElement {
     return count;
   }
 
+  countHiddenByDepth(replies) {
+    let count = 0;
+    for (const reply of replies) {
+      if (!this.shouldFilterComment(reply)) {
+        count++; // Count this reply
+        if (reply.replies?.length) {
+          count += this.countHiddenByDepth(reply.replies); // Count nested replies
+        }
+      }
+    }
+    return count;
+  }
+
   showMoreReplies(event) {
     const button = event.target;
     const postId = button.getAttribute('data-post-id');
@@ -287,6 +304,22 @@ class BlueskyComments extends HTMLElement {
       this.postVisibilityCounts.get(postId) || this.nShowInit;
     const newCount = currentCount + this.nShowMore;
     this.postVisibilityCounts.set(postId, newCount);
+
+    // Re-render the comment with updated visibility
+    this.render();
+  }
+
+  showMoreDepth(event) {
+    const button = event.target;
+    const postId = button.getAttribute('data-post-id');
+    if (!postId) return;
+
+    if (this.postVisibilityCounts.has(postId)) {
+      // Nothing to do, already expanded
+      return;
+    }
+
+    this.postVisibilityDepths.add(postId);
 
     // Re-render the comment with updated visibility
     this.render();
@@ -476,6 +509,21 @@ class BlueskyComments extends HTMLElement {
   renderReplies(replies, depth) {
     if (!replies?.length) return '';
 
+    const parentId = replies[0].post.record.reply.parent.uri;
+
+    if (this.postVisibilityDepths.has(parentId)) {
+      depth = depth - 1;
+    }
+
+    // If we're beyond or at depth limit, show the "show more depth" button
+    if (depth >= this.nShowDepth) {
+      const hiddenCount = this.countHiddenByDepth(replies);
+      if (hiddenCount > 0) {
+        return this.renderShowMoreDepthButton(parentId, hiddenCount);
+      }
+      return '';
+    }
+
     return `
       <div class="replies">
         ${replies
@@ -498,6 +546,17 @@ class BlueskyComments extends HTMLElement {
 
     return `
       <button class="show-more-replies" data-post-id="${postId}">${txtButton}</button>
+    `;
+  }
+
+  renderShowMoreDepthButton(postId, count) {
+    const txtComment =
+      count === 1 ? 'nested reply' : `of ${count} nested replies`;
+    const txtOfCount = count === 1 ? '' : `of ${count}`;
+    return `
+      <button class="show-more show-more-depth" data-post-id="${postId}">
+        Show 1 more ${txtComment}
+      </button>
     `;
   }
 
@@ -567,6 +626,11 @@ class BlueskyComments extends HTMLElement {
     // Add event listeners for reply buttons
     this.querySelectorAll('.show-more-replies').forEach(button => {
       button.addEventListener('click', this.showMoreReplies);
+    });
+
+    // Add event listeners for depth buttons
+    this.querySelectorAll('.show-more-depth').forEach(button => {
+      button.addEventListener('click', this.showMoreDepth);
     });
   }
 

--- a/_extensions/bluesky-comments/bluesky-comments.js
+++ b/_extensions/bluesky-comments/bluesky-comments.js
@@ -59,7 +59,7 @@ class BlueskyComments extends HTMLElement {
       if (typeof value !== 'number') {
         value = parseInt(value);
         if (!isNaN(value)) {
-          this[prop] = value;
+          this[prop] = Math.max(value, 1);
         }
       }
     });

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -89,6 +89,8 @@ You can use this information to replace the source post URL with the resolved AT
 
 ## Configuration
 
+### How to configure Bluesky comments
+
 The extension can be configured through your document's YAML frontmatter or the `_quarto.yml` configuration file. Add configuration options under the `bluesky-comments` key:
 
 ```yaml
@@ -105,20 +107,35 @@ bluesky-comments:
   filter-empty-replies: true
   n-show-init: 3
   n-show-more: 2
+  n-show-depth: 3
 ---
 ```
 
+Each of these options can also be set directly for a single comments section by providing the option as an inline attribute in the shortcode, e.g. `{{{< bluesky-comments n-show-init=3 >}}}`. These values take precedence over the above settings.
+
 ### Available Options
 
-- `profile`: A string with the user profile as a handle or [decentralized identifier](faq.qmd#convert-to-atproto-uri)
-- `mute-patterns`: An array of strings or regex patterns (enclosed in `/`) to filter out comments containing specific text
-- `mute-users`: An array of Bluesky DIDs to filter out comments from specific users
-- `filter-empty-replies`: Boolean flag to filter out empty or very short replies, including bookmarking (📌) replies (default: `true`)
-- `n-show-init`: Number of top-level comments to show initially (default: `3`)
-- `n-show-more`: Number of replies to reveal when the user clicks on the "Show more" button (default: `2`)
-- `header`: Whether or not to add a level-2 header above the comments. Use `header="true"` as a shortcut for `header="Comments"` (default: `false`).
+`mute-patterns`
+:    An array of strings or regex patterns (enclosed in `/`) to filter out comments containing specific text.
 
-Users can click "Show more" buttons to reveal additional comments and replies beyond these initial limits.
+`mute-users`
+:    An array of Bluesky DIDs to filter out comments from specific users.
+
+`filter-empty-replies`
+:    Boolean flag to filter out empty or very short replies, including bookmarking (📌) replies (default: `true`).
+
+`n-show-init`
+:    Number of top-level comments to show initially (default: `3`).
+
+`n-show-more`
+:    Number of replies to reveal when the user clicks on the "Show more" button (default: `2`).
+
+`n-show-depth`
+:    Maximum depth of replies to show initially. Additional nested replies are revealed when the user clicks on the "Show nested replies" button.
+
+`header`
+:    Whether or not to add a level-2 header above the comments. Use `header="true"` as a shortcut for `header="Comments"` (default: `false`).
+
 
 ## Moderation
 


### PR DESCRIPTION
Fixes #15

Adds an `n-show-depth` option that limits the initial depth of the reply tree.

<img width="673" alt="image" src="https://github.com/user-attachments/assets/3191ed4b-6b1e-4fc4-8215-96cb32affa9d" />
